### PR TITLE
Multiple skeleton loaders

### DIFF
--- a/src/components/SuggestionsListClient.tsx
+++ b/src/components/SuggestionsListClient.tsx
@@ -220,6 +220,11 @@ export function SuggestionsListClient({ appid }: { appid: number }) {
 
   // No suggestions yet (still generating / waiting)
   if (suggestions.length === 0) {
+    if (generating) {
+      // Show a few skeleton cards while generation runs (and only show the notice after a short delay).
+      return <SuggestionsSkeleton showNotice={showSlowNotice} count={4} />;
+    }
+
     return (
       <Card>
         <CardHeader>

--- a/src/components/SuggestionsSkeleton.tsx
+++ b/src/components/SuggestionsSkeleton.tsx
@@ -2,7 +2,13 @@ import { Loader2 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
-export function SuggestionsSkeleton({ showNotice = false }: { showNotice?: boolean }) {
+export function SuggestionsSkeleton({
+  showNotice = false,
+  count = 6,
+}: {
+  showNotice?: boolean;
+  count?: number;
+}) {
   return (
     <div className="flex flex-col gap-4">
       {showNotice && (
@@ -18,7 +24,7 @@ export function SuggestionsSkeleton({ showNotice = false }: { showNotice?: boole
         </Alert>
       )}
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
-        {Array.from({ length: 6 }).map((_, index) => (
+        {Array.from({ length: count }).map((_, index) => (
           <div key={index} className="flex flex-col">
             <Skeleton className="w-full aspect-steam mb-2" />
             <Skeleton className="h-4 w-3/4" />


### PR DESCRIPTION
Add multiple skeleton cards to the "this might take a while" loading state to improve visual feedback.

---
[Slack Thread](https://thinkhumanco.slack.com/archives/C0A6ST1ELUR/p1767306650478219?thread_ts=1767306650.478219&cid=C0A6ST1ELUR)

<a href="https://cursor.com/background-agent?bcId=bc-aa2d831e-c29b-4fa8-ae04-6a0f22f129e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa2d831e-c29b-4fa8-ae04-6a0f22f129e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

