### PR TITLE
Page scroll to top

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Inter } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
+import { ScrollToTopOnNavigation } from "@/components/ScrollToTopOnNavigation";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -52,6 +53,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <ScrollToTopOnNavigation />
         {children}
         <Analytics />
       </body>

--- a/src/components/ScrollToTopOnNavigation.tsx
+++ b/src/components/ScrollToTopOnNavigation.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+/**
+ * Scrolls to top on client-side navigations (push/replace).
+ * Keeps native scroll restoration on back/forward.
+ */
+export function ScrollToTopOnNavigation() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isPopStateRef = useRef(false);
+
+  useEffect(() => {
+    const onPopState = () => {
+      isPopStateRef.current = true;
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  useEffect(() => {
+    // If the URL includes a hash, let the browser/Next handle anchor scrolling.
+    if (window.location.hash) return;
+
+    // If this navigation was a back/forward, preserve the restored position.
+    if (isPopStateRef.current) {
+      isPopStateRef.current = false;
+      return;
+    }
+
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [pathname, searchParams]);
+
+  return null;
+}
+


### PR DESCRIPTION
Add a `ScrollToTopOnNavigation` component to automatically scroll pages to the top on client-side navigation.

---
[Slack Thread](https://thinkhumanco.slack.com/archives/C0A6ST1ELUR/p1767308013783329?thread_ts=1767308013.783329&cid=C0A6ST1ELUR)

<a href="https://cursor.com/background-agent?bcId=bc-12093e27-3eb3-485f-9554-6eab5c55a974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12093e27-3eb3-485f-9554-6eab5c55a974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

