### PR TITLE
Homepage custom lists and collections

### DIFF
--- a/src/app/api/collections/[id]/route.ts
+++ b/src/app/api/collections/[id]/route.ts
@@ -1,0 +1,152 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getSupabaseServerClient } from "@/lib/supabase/server";
+import { getSupabaseServiceRoleClient } from "@/lib/supabase/service";
+
+function isAdmin(request: Request): boolean {
+  const expected = process.env.COLLECTIONS_ADMIN_TOKEN;
+  if (!expected) return false;
+  const auth = request.headers.get("authorization") || "";
+  const token = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
+  return token === expected;
+}
+
+const IdSchema = z.string().uuid();
+
+const PatchSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  pinned: z.boolean().optional(),
+  pinned_rank: z.number().int().optional(),
+  addAppids: z.array(z.number().int().positive()).max(200).optional(),
+  removeAppids: z.array(z.number().int().positive()).max(200).optional(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const collectionId = IdSchema.parse(id);
+
+    const supabase = getSupabaseServerClient();
+    const { data: collection, error: collectionError } = await supabase
+      .from("collections")
+      .select("id, title, description, pinned, pinned_rank, created_at, updated_at")
+      .eq("id", collectionId)
+      .maybeSingle();
+
+    if (collectionError) {
+      return NextResponse.json({ error: collectionError.message }, { status: 500 });
+    }
+    if (!collection) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const { data: items, error: itemsError } = await supabase
+      .from("collection_items")
+      .select(
+        "created_at, games_new(appid, title, header_image, screenshots, videos, short_description, long_description, raw, suggested_game_appids, created_at, updated_at)"
+      )
+      .eq("collection_id", collectionId)
+      .order("created_at", { ascending: false });
+
+    if (itemsError) {
+      return NextResponse.json({ error: itemsError.message }, { status: 500 });
+    }
+
+    const games = (items || [])
+      .map((row) => {
+        const embedded = row.games_new as unknown;
+        if (Array.isArray(embedded)) return embedded[0] ?? null;
+        return embedded ?? null;
+      })
+      .filter(Boolean);
+
+    return NextResponse.json({ collection, games });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request", details: err.issues },
+        { status: 400 }
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    if (!isAdmin(request)) {
+      return NextResponse.json(
+        {
+          error:
+            "Forbidden. Set COLLECTIONS_ADMIN_TOKEN and call with Authorization: Bearer <token>.",
+        },
+        { status: 403 }
+      );
+    }
+
+    const { id } = await params;
+    const collectionId = IdSchema.parse(id);
+    const body = PatchSchema.parse(await request.json());
+    const supabase = getSupabaseServiceRoleClient();
+
+    const updates: Record<string, unknown> = {};
+    if (typeof body.title === "string") updates.title = body.title;
+    if (typeof body.description === "string") updates.description = body.description;
+    if (typeof body.pinned === "boolean") updates.pinned = body.pinned;
+    if (typeof body.pinned_rank === "number") updates.pinned_rank = body.pinned_rank;
+
+    if (Object.keys(updates).length > 0) {
+      const { error: updateError } = await supabase
+        .from("collections")
+        .update(updates)
+        .eq("id", collectionId);
+      if (updateError) {
+        return NextResponse.json({ error: updateError.message }, { status: 500 });
+      }
+    }
+
+    if (body.addAppids && body.addAppids.length > 0) {
+      const rows = body.addAppids.map((appid) => ({
+        collection_id: collectionId,
+        appid,
+      }));
+      const { error: insertError } = await supabase
+        .from("collection_items")
+        .insert(rows, { defaultToNull: false });
+      if (insertError) {
+        return NextResponse.json({ error: insertError.message }, { status: 500 });
+      }
+    }
+
+    if (body.removeAppids && body.removeAppids.length > 0) {
+      const { error: deleteError } = await supabase
+        .from("collection_items")
+        .delete()
+        .eq("collection_id", collectionId)
+        .in("appid", body.removeAppids);
+      if (deleteError) {
+        return NextResponse.json({ error: deleteError.message }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: err.issues },
+        { status: 400 }
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getSupabaseServerClient } from "@/lib/supabase/server";
+import { getSupabaseServiceRoleClient } from "@/lib/supabase/service";
+
+function isAdmin(request: Request): boolean {
+  const expected = process.env.COLLECTIONS_ADMIN_TOKEN;
+  if (!expected) return false;
+  const auth = request.headers.get("authorization") || "";
+  const token = auth.startsWith("Bearer ") ? auth.slice("Bearer ".length) : "";
+  return token === expected;
+}
+
+const CreateCollectionSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  pinned: z.boolean().optional(),
+  pinned_rank: z.number().int().optional(),
+  appids: z.array(z.number().int().positive()).max(200).optional(),
+});
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const pinnedOnly = url.searchParams.get("pinned") === "true";
+
+    const supabase = getSupabaseServerClient();
+    let query = supabase
+      .from("collections")
+      .select("id, title, description, pinned, pinned_rank, created_at, updated_at");
+
+    if (pinnedOnly) {
+      query = query
+        .eq("pinned", true)
+        .order("pinned_rank", { ascending: false })
+        .order("created_at", { ascending: false });
+    } else {
+      query = query
+        .order("pinned", { ascending: false })
+        .order("pinned_rank", { ascending: false })
+        .order("created_at", { ascending: false });
+    }
+
+    const { data, error } = await query.limit(100);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ collections: data || [] });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    if (!isAdmin(request)) {
+      return NextResponse.json(
+        {
+          error:
+            "Forbidden. Set COLLECTIONS_ADMIN_TOKEN and call with Authorization: Bearer <token>.",
+        },
+        { status: 403 }
+      );
+    }
+
+    const body = CreateCollectionSchema.parse(await request.json());
+    const supabase = getSupabaseServiceRoleClient();
+
+    const { data: created, error: createError } = await supabase
+      .from("collections")
+      .insert({
+        title: body.title,
+        description: body.description ?? null,
+        pinned: body.pinned ?? false,
+        pinned_rank: body.pinned_rank ?? 0,
+      })
+      .select("id, title, description, pinned, pinned_rank, created_at, updated_at")
+      .single();
+
+    if (createError || !created) {
+      return NextResponse.json(
+        { error: createError?.message || "Failed to create collection" },
+        { status: 500 }
+      );
+    }
+
+    if (body.appids && body.appids.length > 0) {
+      const rows = body.appids.map((appid) => ({
+        collection_id: created.id,
+        appid,
+      }));
+      const { error: itemsError } = await supabase
+        .from("collection_items")
+        .insert(rows);
+      if (itemsError) {
+        return NextResponse.json(
+          {
+            error: itemsError.message,
+            collection: created,
+          },
+          { status: 500 }
+        );
+      }
+    }
+
+    return NextResponse.json({ collection: created }, { status: 201 });
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Invalid request body", details: err.issues },
+        { status: 400 }
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+

--- a/src/app/collections/[id]/loading.tsx
+++ b/src/app/collections/[id]/loading.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <main className="container mx-auto max-w-7xl px-4 py-6 sm:py-8 flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-40" />
+        <Skeleton className="h-8 w-72 max-w-full" />
+        <Skeleton className="h-4 w-96 max-w-full" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {Array.from({ length: 9 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-2">
+            <Skeleton className="w-full aspect-steam rounded-md" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-3 w-full" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}
+

--- a/src/app/collections/[id]/page.tsx
+++ b/src/app/collections/[id]/page.tsx
@@ -1,0 +1,141 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { z } from "zod";
+import { getSupabaseServerClient } from "@/lib/supabase/server";
+import type { Collection, GameNew } from "@/lib/supabase/types";
+import GameCard from "@/components/GameCard";
+
+export const dynamic = "force-dynamic";
+
+const IdSchema = z.string().uuid();
+
+async function getCollection(id: string): Promise<Collection | null> {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("collections")
+    .select("id, title, description, pinned, pinned_rank, created_at, updated_at")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Error loading collection:", error);
+    return null;
+  }
+  return (data as Collection | null) ?? null;
+}
+
+async function getCollectionGames(id: string): Promise<GameNew[]> {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("collection_items")
+    .select(
+      "created_at, games_new(appid, title, header_image, screenshots, videos, short_description, long_description, raw, suggested_game_appids, created_at, updated_at)"
+    )
+    .eq("collection_id", id)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error loading collection items:", error);
+    return [];
+  }
+
+  return (data || [])
+    .map((row) => {
+      const embedded = row.games_new as unknown;
+      if (Array.isArray(embedded)) {
+        return (embedded[0] as GameNew | undefined) ?? null;
+      }
+      return (embedded as GameNew | null) ?? null;
+    })
+    .filter((g): g is GameNew => !!g);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const parsed = IdSchema.safeParse(id);
+  if (!parsed.success) {
+    return { title: "Collection Not Found" };
+  }
+
+  const collection = await getCollection(parsed.data);
+  if (!collection) {
+    return { title: "Collection Not Found", robots: { index: false, follow: false } };
+  }
+
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "https://www.indiefindr.gg";
+  const canonicalUrl = `${siteUrl}/collections/${collection.id}`;
+
+  return {
+    title: `${collection.title} — IndieFindr`,
+    description: collection.description ?? undefined,
+    alternates: { canonical: canonicalUrl },
+    openGraph: {
+      title: `${collection.title} — IndieFindr`,
+      description: collection.description ?? undefined,
+      url: canonicalUrl,
+      siteName: "IndieFindr",
+      locale: "en_US",
+      type: "website",
+    },
+  };
+}
+
+export default async function CollectionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const parsed = IdSchema.safeParse(id);
+  if (!parsed.success) notFound();
+
+  const [collection, games] = await Promise.all([
+    getCollection(parsed.data),
+    getCollectionGames(parsed.data),
+  ]);
+
+  if (!collection) notFound();
+
+  return (
+    <main className="container mx-auto max-w-7xl px-4 py-6 sm:py-8 flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <div className="text-sm text-muted-foreground">
+          <Link href="/" className="hover:underline">
+            Home
+          </Link>{" "}
+          <span aria-hidden="true">/</span>{" "}
+          <span className="text-foreground">{collection.title}</span>
+        </div>
+
+        <h1 className="text-xl sm:text-2xl font-semibold leading-snug text-balance">
+          {collection.title}
+        </h1>
+
+        {collection.description ? (
+          <p className="text-muted-foreground max-w-3xl">
+            {collection.description}
+          </p>
+        ) : null}
+      </div>
+
+      {games.length === 0 ? (
+        <p className="text-muted-foreground">
+          This collection doesn’t have any games yet.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {games.map((game) => (
+            <GameCard key={game.appid} {...game} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+type CollectionCardProps = {
+  id: string;
+  title: string;
+  description?: string | null;
+  coverImages?: string[];
+};
+
+export function CollectionCard({
+  id,
+  title,
+  description,
+  coverImages = [],
+}: CollectionCardProps) {
+  const covers = coverImages.filter(Boolean).slice(0, 4);
+  const tiles = [covers[0], covers[1], covers[2], covers[3]];
+
+  return (
+    <Link
+      href={`/collections/${id}`}
+      className="block snap-start min-w-[260px] max-w-[260px]"
+    >
+      <Card
+        size="sm"
+        className="gap-0 py-0 overflow-hidden transition-colors hover:bg-muted/30"
+      >
+        <div className="grid grid-cols-2 grid-rows-2 gap-px bg-muted aspect-video">
+          {covers.length === 0 ? (
+            <div className="col-span-2 row-span-2 flex items-center justify-center text-xs text-muted-foreground">
+              Empty collection
+            </div>
+          ) : (
+            tiles.map((src, idx) => (
+              <div key={idx} className="relative">
+                {src ? (
+                  <Image
+                    src={src}
+                    alt={title}
+                    fill
+                    sizes="260px"
+                    className="object-cover"
+                  />
+                ) : null}
+              </div>
+            ))
+          )}
+        </div>
+
+        <CardHeader className="pb-0">
+          <CardTitle className="line-clamp-1">{title}</CardTitle>
+          {description ? (
+            <CardDescription className="line-clamp-2">
+              {description}
+            </CardDescription>
+          ) : null}
+        </CardHeader>
+
+        {/* Keep spacing consistent even without description */}
+        <CardContent className="pt-2" />
+      </Card>
+    </Link>
+  );
+}
+

--- a/src/components/PinnedCollectionsRow.tsx
+++ b/src/components/PinnedCollectionsRow.tsx
@@ -1,0 +1,40 @@
+import { CollectionCard } from "@/components/CollectionCard";
+
+export type PinnedCollectionPreview = {
+  id: string;
+  title: string;
+  description: string | null;
+  coverImages: string[];
+};
+
+export function PinnedCollectionsRow({
+  collections,
+  title = "Pinned lists",
+}: {
+  collections: PinnedCollectionPreview[];
+  title?: string;
+}) {
+  if (collections.length === 0) return null;
+
+  return (
+    <section className="w-full px-4">
+      <div className="container mx-auto max-w-7xl w-full flex items-center justify-between">
+        <h2 className="font-semibold text-xl">{title}</h2>
+      </div>
+      <div className="container mx-auto max-w-7xl w-full">
+        <div className="mt-3 flex gap-3 overflow-x-auto pb-2 snap-x snap-mandatory [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {collections.map((c) => (
+            <CollectionCard
+              key={c.id}
+              id={c.id}
+              title={c.title}
+              description={c.description}
+              coverImages={c.coverImages}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/src/lib/supabase/service.ts
+++ b/src/lib/supabase/service.ts
@@ -1,0 +1,32 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let cachedServiceClient: SupabaseClient | null = null;
+
+/**
+ * Server-side Supabase client using the service role key (bypasses RLS).
+ *
+ * IMPORTANT: Only import/use this from server-only code (API routes, server actions).
+ * Never expose the service role key to the browser.
+ */
+export function getSupabaseServiceRoleClient(): SupabaseClient {
+  if (cachedServiceClient) return cachedServiceClient;
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set to use the service role client"
+    );
+  }
+
+  cachedServiceClient = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  return cachedServiceClient;
+}
+

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -17,3 +17,19 @@ export type GameNew = {
   created_at: string;
   updated_at: string;
 };
+
+export type Collection = {
+  id: string;
+  title: string;
+  description: string | null;
+  pinned: boolean;
+  pinned_rank: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CollectionItem = {
+  collection_id: string;
+  appid: number;
+  created_at: string;
+};

--- a/supabase/migrations/20260104000000_add_collections.sql
+++ b/supabase/migrations/20260104000000_add_collections.sql
@@ -1,0 +1,73 @@
+-- Collections (custom lists) + items
+-- Used for pinned rows on home and collection detail pages.
+
+CREATE TABLE IF NOT EXISTS collections (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  description TEXT,
+  pinned BOOLEAN NOT NULL DEFAULT FALSE,
+  pinned_rank INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS collection_items (
+  collection_id UUID NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+  appid BIGINT NOT NULL REFERENCES games_new(appid) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (collection_id, appid)
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_collections_pinned_rank
+  ON collections(pinned, pinned_rank, created_at);
+CREATE INDEX IF NOT EXISTS idx_collection_items_collection_id
+  ON collection_items(collection_id);
+CREATE INDEX IF NOT EXISTS idx_collection_items_appid
+  ON collection_items(appid);
+
+-- updated_at triggers
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgname = 'update_collections_updated_at'
+  ) THEN
+    CREATE TRIGGER update_collections_updated_at
+      BEFORE UPDATE ON collections
+      FOR EACH ROW
+      EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
+
+-- RLS
+ALTER TABLE collections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE collection_items ENABLE ROW LEVEL SECURITY;
+
+-- Public read-only (mutations should use service role / admin routes)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'collections'
+      AND policyname = 'Allow public read access to collections'
+  ) THEN
+    CREATE POLICY "Allow public read access to collections" ON collections
+      FOR SELECT USING (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'collection_items'
+      AND policyname = 'Allow public read access to collection_items'
+  ) THEN
+    CREATE POLICY "Allow public read access to collection_items" ON collection_items
+      FOR SELECT USING (true);
+  END IF;
+END $$;
+


### PR DESCRIPTION
Adds support for custom game collections, including pinning them to the home page in a side-scrolling row and providing a dedicated detail page.

This PR introduces a new Supabase schema for `collections` and `collection_items`, implements a horizontally scrollable "Pinned lists" row on the home page, and creates a dynamic route (`/collections/[id]`) for viewing collection details. Admin CRUD APIs for collections are also included, protected by a `COLLECTIONS_ADMIN_TOKEN`.

---
[Slack Thread](https://thinkhumanco.slack.com/archives/C0A6ST1ELUR/p1767488081831469?thread_ts=1767488081.831469&cid=C0A6ST1ELUR)

<a href="https://cursor.com/background-agent?bcId=bc-1cba7dcc-bad9-4eba-ac96-a9a010c7833c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cba7dcc-bad9-4eba-ac96-a9a010c7833c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

