### PR TITLE
Cursor 2000s aesthetic redesign

### DIFF
--- a/src/app/games/[appid]/loading.tsx
+++ b/src/app/games/[appid]/loading.tsx
@@ -3,30 +3,40 @@ import { SuggestionsSkeleton } from "@/components/SuggestionsSkeleton";
 
 export default function GamePageLoading() {
   return (
-    <main className="container mx-auto max-w-4xl px-4 py-6 sm:py-8 flex flex-col gap-3 sm:gap-4">
-      {/* Title skeleton */}
-      <Skeleton className="h-8 w-64" />
+    <main className="px-4 py-6 sm:py-8">
+      <div className="container mx-auto max-w-6xl w-full">
+        <section className="retro-window">
+          <div className="retro-titlebar">
+            <div className="retro-titlebar-title">IndieFindr Recommendations</div>
+            <div className="retro-titlebar-meta">Loading…</div>
+          </div>
+          <div className="retro-window-body flex flex-col gap-3 sm:gap-4">
+            {/* Title skeleton */}
+            <Skeleton className="h-8 w-64" />
 
-      {/* Video skeleton */}
-      <Skeleton className="w-full aspect-video" />
+            {/* Video skeleton */}
+            <Skeleton className="w-full aspect-video" />
 
-      {/* Game header skeleton */}
-      <div className="flex gap-3 sm:gap-4 items-center mb-4">
-        <div className="flex-1 flex flex-col min-w-0 gap-2">
-          <Skeleton className="h-6 w-3/4" />
-          <Skeleton className="h-4 w-full" />
-          <Skeleton className="h-4 w-2/3" />
-          <Skeleton className="h-8 w-32 mt-2" />
-        </div>
-      </div>
+            {/* Game header skeleton */}
+            <div className="flex gap-3 sm:gap-4 items-center mb-4">
+              <div className="flex-1 flex flex-col min-w-0 gap-2">
+                <Skeleton className="h-6 w-3/4" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-8 w-32 mt-2" />
+              </div>
+            </div>
 
-      {/* Suggestions section skeleton */}
-      <div className="flex flex-col gap-2">
-        <div className="flex sm:items-center justify-between gap-2">
-          <Skeleton className="h-6 w-48" />
-          <Skeleton className="h-9 w-32" />
-        </div>
-        <SuggestionsSkeleton showNotice={false} />
+            {/* Suggestions section skeleton */}
+            <div className="flex flex-col gap-2">
+              <div className="flex sm:items-center justify-between gap-2">
+                <Skeleton className="h-6 w-48" />
+                <Skeleton className="h-9 w-32" />
+              </div>
+              <SuggestionsSkeleton showNotice={false} />
+            </div>
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/src/app/games/[appid]/page.tsx
+++ b/src/app/games/[appid]/page.tsx
@@ -349,6 +349,10 @@ export default async function GameDetailPage({
               <GameContent appId={appId} appid={appid} />
             </Suspense>
           </div>
+          <div className="retro-statusbar">
+            <span>Status: Streaming</span>
+            <span className="opacity-80">Powered by Steam + AI</span>
+          </div>
         </section>
       </div>
     </main>

--- a/src/app/games/[appid]/page.tsx
+++ b/src/app/games/[appid]/page.tsx
@@ -314,33 +314,43 @@ export default async function GameDetailPage({
   }
 
   return (
-    <main className="container mx-auto max-w-4xl px-4 py-6 sm:py-8 flex flex-col gap-3 sm:gap-4">
-      <Suspense
-        fallback={
-          <>
-            {/* Main content skeleton */}
-            <Skeleton className="h-8 w-64" />
-            <Skeleton className="w-full aspect-video" />
-            <div className="flex gap-3 sm:gap-4 items-center mb-4">
-              <div className="flex-1 flex flex-col min-w-0 gap-2">
-                <Skeleton className="h-6 w-3/4" />
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-4 w-2/3" />
-                <Skeleton className="h-8 w-32 mt-2" />
-              </div>
-            </div>
-            {/* Suggestions section skeleton */}
-            <div className="flex flex-col gap-3">
-              <div className="flex items-start sm:items-center justify-between gap-3">
-                <Skeleton className="h-6 w-64 max-w-full" />
-              </div>
-              <SuggestionsSkeleton showNotice={false} />
-            </div>
-          </>
-        }
-      >
-        <GameContent appId={appId} appid={appid} />
-      </Suspense>
+    <main className="px-4 py-6 sm:py-8">
+      <div className="container mx-auto max-w-6xl w-full">
+        <section className="retro-window">
+          <div className="retro-titlebar">
+            <div className="retro-titlebar-title">IndieFindr Recommendations</div>
+            <div className="retro-titlebar-meta">AppID: {appid}</div>
+          </div>
+          <div className="retro-window-body flex flex-col gap-3 sm:gap-4">
+            <Suspense
+              fallback={
+                <>
+                  {/* Main content skeleton */}
+                  <Skeleton className="h-8 w-64" />
+                  <Skeleton className="w-full aspect-video" />
+                  <div className="flex gap-3 sm:gap-4 items-center mb-4">
+                    <div className="flex-1 flex flex-col min-w-0 gap-2">
+                      <Skeleton className="h-6 w-3/4" />
+                      <Skeleton className="h-4 w-full" />
+                      <Skeleton className="h-4 w-2/3" />
+                      <Skeleton className="h-8 w-32 mt-2" />
+                    </div>
+                  </div>
+                  {/* Suggestions section skeleton */}
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-start sm:items-center justify-between gap-3">
+                      <Skeleton className="h-6 w-64 max-w-full" />
+                    </div>
+                    <SuggestionsSkeleton showNotice={false} />
+                  </div>
+                </>
+              }
+            >
+              <GameContent appId={appId} appid={appid} />
+            </Suspense>
+          </div>
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -179,6 +179,7 @@
 @layer components {
   /* Desktop backdrop: subtle pattern + gentle vignette */
   .retro-desktop {
+    position: relative;
     background:
       radial-gradient(1200px 700px at 30% 0%, rgba(255, 255, 255, 0.65), transparent 60%),
       radial-gradient(900px 600px at 100% 40%, rgba(255, 255, 255, 0.35), transparent 55%),
@@ -192,15 +193,63 @@
       linear-gradient(to bottom, #d2deea, #b7c4d3 40%, #b2c0d0);
   }
 
+  /* CRT overlay (scanlines + faint noise/flicker) */
+  .retro-crt {
+    position: relative;
+  }
+
+  .retro-crt::before {
+    content: "";
+    pointer-events: none;
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    background:
+      repeating-linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0.06) 0px,
+        rgba(0, 0, 0, 0.06) 1px,
+        transparent 2px,
+        transparent 4px
+      ),
+      radial-gradient(1000px 500px at 50% 0%, rgba(255, 255, 255, 0.10), transparent 70%);
+    mix-blend-mode: multiply;
+    opacity: 0.35;
+  }
+
+  .retro-crt::after {
+    content: "";
+    pointer-events: none;
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    background:
+      radial-gradient(2px 2px at 10% 20%, rgba(255, 255, 255, 0.14), transparent 60%),
+      radial-gradient(2px 2px at 40% 60%, rgba(0, 0, 0, 0.10), transparent 60%),
+      radial-gradient(2px 2px at 75% 35%, rgba(255, 255, 255, 0.10), transparent 60%),
+      radial-gradient(2px 2px at 90% 80%, rgba(0, 0, 0, 0.10), transparent 60%);
+    opacity: 0.22;
+    animation: retro-flicker 7s infinite linear;
+  }
+
+  @keyframes retro-flicker {
+    0%, 100% { opacity: 0.20; }
+    48% { opacity: 0.26; }
+    50% { opacity: 0.18; }
+    52% { opacity: 0.28; }
+  }
+
   /* Window/panel framing */
   .retro-window {
     background: linear-gradient(to bottom, var(--retro-surface), var(--retro-surface-2));
-    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    border: 2px solid color-mix(in srgb, var(--border) 72%, white 28%);
     border-radius: calc(var(--radius) + 2px);
     box-shadow:
       0 16px 45px var(--retro-shadow),
+      0 0 0 1px rgba(255, 255, 255, 0.45),
       inset 1px 1px 0 var(--retro-bevel-hi),
-      inset -1px -1px 0 var(--retro-bevel-lo);
+      inset -1px -1px 0 var(--retro-bevel-lo),
+      inset 0 0 0 1px rgba(0, 0, 0, 0.10);
     overflow: hidden;
   }
 
@@ -221,10 +270,59 @@
     justify-content: space-between;
     gap: 0.75rem;
     padding: 0.5rem 0.75rem;
-    background: linear-gradient(to bottom, var(--retro-titlebar-top), var(--retro-titlebar-bottom));
+    position: relative;
+    background:
+      repeating-linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.10) 0px,
+        rgba(255, 255, 255, 0.10) 8px,
+        rgba(0, 0, 0, 0.06) 8px,
+        rgba(0, 0, 0, 0.06) 16px
+      ),
+      linear-gradient(to bottom, var(--retro-titlebar-top), var(--retro-titlebar-bottom));
     color: var(--retro-titlebar-text);
     border-bottom: 1px solid rgba(0, 0, 0, 0.25);
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
+  }
+
+  .retro-titlebar::before {
+    content: "";
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.55),
+      rgba(255, 255, 255, 0.12) 40%,
+      rgba(255, 255, 255, 0) 75%
+    );
+    opacity: 0.65;
+  }
+
+  .retro-titlebar::after {
+    content: "";
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      120deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0.38) 45%,
+      transparent 65%
+    );
+    opacity: 0.0;
+    animation: retro-glint 9s infinite ease-in-out;
+  }
+
+  @keyframes retro-glint {
+    0%, 22% { opacity: 0; transform: translateX(-40%); }
+    26% { opacity: 0.35; }
+    34% { opacity: 0.0; transform: translateX(40%); }
+    100% { opacity: 0; transform: translateX(40%); }
+  }
+
+  .retro-titlebar--compact {
+    padding: 0.35rem 0.6rem;
   }
 
   .retro-titlebar-title {
@@ -245,7 +343,16 @@
 
   .retro-window-body {
     padding: 1rem;
-    background: var(--card);
+    background:
+      radial-gradient(600px 200px at 20% 0%, rgba(255, 255, 255, 0.55), transparent 60%),
+      repeating-linear-gradient(
+        0deg,
+        rgba(0, 0, 0, 0.02) 0px,
+        rgba(0, 0, 0, 0.02) 1px,
+        transparent 1px,
+        transparent 6px
+      ),
+      var(--card);
   }
 
   .retro-menubar {
@@ -256,6 +363,124 @@
     box-shadow:
       0 14px 35px rgba(15, 23, 42, 0.22),
       inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  }
+
+  .retro-window-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding-left: 0.25rem;
+  }
+
+  .retro-dot {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 999px;
+    box-shadow:
+      inset 1px 1px 0 rgba(255, 255, 255, 0.65),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.25),
+      0 1px 0 rgba(0, 0, 0, 0.25);
+  }
+
+  .retro-dot--close { background: linear-gradient(to bottom, #ff7a7a, #d62424); }
+  .retro-dot--min { background: linear-gradient(to bottom, #ffe08a, #d8a616); }
+  .retro-dot--max { background: linear-gradient(to bottom, #9bff9b, #12a33a); }
+
+  .retro-statusbar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+    color: rgba(15, 23, 42, 0.85);
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.9), rgba(219, 230, 242, 0.95));
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  }
+
+  .retro-statusbar::after {
+    content: "";
+    width: 22px;
+    height: 12px;
+    opacity: 0.55;
+    background:
+      repeating-linear-gradient(
+        135deg,
+        rgba(0, 0, 0, 0.25) 0px,
+        rgba(0, 0, 0, 0.25) 1px,
+        transparent 1px,
+        transparent 4px
+      );
+    border-left: 1px solid rgba(0, 0, 0, 0.10);
+    padding-left: 0.5rem;
+  }
+
+  .retro-eq {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 14px;
+    padding: 0 0.35rem;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.18);
+    box-shadow:
+      inset 1px 1px 0 rgba(255, 255, 255, 0.20),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.30);
+  }
+
+  .retro-eq > span {
+    width: 3px;
+    height: 6px;
+    border-radius: 2px;
+    background: linear-gradient(to bottom, #b8ff66, #4ed60a);
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
+    animation: retro-eq 900ms infinite ease-in-out;
+  }
+
+  .retro-eq > span:nth-child(2) { animation-duration: 760ms; height: 9px; }
+  .retro-eq > span:nth-child(3) { animation-duration: 640ms; height: 12px; }
+  .retro-eq > span:nth-child(4) { animation-duration: 820ms; height: 8px; }
+  .retro-eq > span:nth-child(5) { animation-duration: 700ms; height: 10px; }
+
+  @keyframes retro-eq {
+    0%, 100% { transform: scaleY(0.55); filter: brightness(0.95); }
+    50% { transform: scaleY(1.15); filter: brightness(1.1); }
+  }
+
+  .retro-listitem {
+    position: relative;
+  }
+
+  .retro-listitem:hover {
+    background:
+      linear-gradient(to bottom, rgba(120, 180, 255, 0.55), rgba(45, 101, 242, 0.25));
+  }
+
+  /* Scrollbars (best-effort, WebKit + Firefox) */
+  * {
+    scrollbar-color: rgba(45, 101, 242, 0.75) rgba(0, 0, 0, 0.10);
+    scrollbar-width: thin;
+  }
+
+  *::-webkit-scrollbar {
+    width: 12px;
+    height: 12px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.55), rgba(0, 0, 0, 0.06));
+    border-left: 1px solid rgba(0, 0, 0, 0.12);
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background: linear-gradient(to bottom, #7db5ff, #2d65f2);
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    border-radius: 999px;
+    box-shadow:
+      inset 1px 1px 0 rgba(255, 255, 255, 0.55),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.18);
   }
 
   /* Controls */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,30 +48,40 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.58 0.22 27);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  /* Early-2000s "desktop" palette (Aqua/XP-ish) */
+  --background: #bfcbd8;
+  --foreground: #0f172a;
+
+  --card: #f6f8fb;
+  --card-foreground: #0f172a;
+
+  --popover: #f6f8fb;
+  --popover-foreground: #0f172a;
+
+  --primary: #2d65f2;
+  --primary-foreground: #ffffff;
+
+  --secondary: #dbe4ee;
+  --secondary-foreground: #0f172a;
+
+  --muted: #e7edf4;
+  --muted-foreground: #334155;
+
+  --accent: #ffd24a;
+  --accent-foreground: #1f2937;
+
+  --destructive: #b42318;
+  --border: #6b7c8f;
+  --input: #ffffff;
+  --ring: #2d65f2;
+
+  /* Charts (keep existing defaults, slightly "web 1.0" saturated) */
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --radius: 0;
+  --radius: 10px;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
@@ -80,27 +90,43 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* Retro UI primitives */
+  --retro-surface: #f6f8fb;
+  --retro-surface-2: #e6edf6;
+  --retro-titlebar-top: #6aa6ff;
+  --retro-titlebar-bottom: #1f4ed6;
+  --retro-titlebar-text: #ffffff;
+  --retro-bevel-hi: rgba(255, 255, 255, 0.9);
+  --retro-bevel-lo: rgba(15, 23, 42, 0.25);
+  --retro-shadow: rgba(15, 23, 42, 0.25);
+  --retro-gloss: rgba(255, 255, 255, 0.45);
+
+  --font-sans: Tahoma, "Trebuchet MS", Verdana, "Lucida Grande",
+    var(--font-inter), var(--font-geist-sans), ui-sans-serif, system-ui,
+    -apple-system, "Segoe UI", Arial, sans-serif;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.87 0.00 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.371 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  /* Winamp-ish dark skin (kept for future theme toggle) */
+  --background: #0b1020;
+  --foreground: #e6f0ff;
+  --card: #0f1730;
+  --card-foreground: #e6f0ff;
+  --popover: #0f1730;
+  --popover-foreground: #e6f0ff;
+  --primary: #59d7ff;
+  --primary-foreground: #051018;
+  --secondary: #17244a;
+  --secondary-foreground: #e6f0ff;
+  --muted: #131c3c;
+  --muted-foreground: #b6c6e6;
+  --accent: #a3ff5a;
+  --accent-foreground: #07110a;
+  --destructive: #ff5a7a;
+  --border: rgba(230, 240, 255, 0.14);
+  --input: rgba(230, 240, 255, 0.10);
+  --ring: #59d7ff;
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
@@ -114,17 +140,197 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+
+  --retro-surface: #0f1730;
+  --retro-surface-2: #131c3c;
+  --retro-titlebar-top: #1d9cff;
+  --retro-titlebar-bottom: #0a3ea8;
+  --retro-titlebar-text: #e6f0ff;
+  --retro-bevel-hi: rgba(230, 240, 255, 0.20);
+  --retro-bevel-lo: rgba(0, 0, 0, 0.55);
+  --retro-shadow: rgba(0, 0, 0, 0.6);
+  --retro-gloss: rgba(255, 255, 255, 0.14);
 }
 
 @layer base {
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    color-scheme: light;
+  }
+  html.dark {
+    color-scheme: dark;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
+    text-rendering: optimizeLegibility;
+  }
+
+  a {
+    @apply underline-offset-4;
   }
 }
 
 .aspect-steam {
   aspect-ratio: 460 / 215;
+}
+
+@layer components {
+  /* Desktop backdrop: subtle pattern + gentle vignette */
+  .retro-desktop {
+    background:
+      radial-gradient(1200px 700px at 30% 0%, rgba(255, 255, 255, 0.65), transparent 60%),
+      radial-gradient(900px 600px at 100% 40%, rgba(255, 255, 255, 0.35), transparent 55%),
+      repeating-linear-gradient(
+        45deg,
+        rgba(255, 255, 255, 0.08) 0px,
+        rgba(255, 255, 255, 0.08) 6px,
+        rgba(0, 0, 0, 0.03) 6px,
+        rgba(0, 0, 0, 0.03) 12px
+      ),
+      linear-gradient(to bottom, #d2deea, #b7c4d3 40%, #b2c0d0);
+  }
+
+  /* Window/panel framing */
+  .retro-window {
+    background: linear-gradient(to bottom, var(--retro-surface), var(--retro-surface-2));
+    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    border-radius: calc(var(--radius) + 2px);
+    box-shadow:
+      0 16px 45px var(--retro-shadow),
+      inset 1px 1px 0 var(--retro-bevel-hi),
+      inset -1px -1px 0 var(--retro-bevel-lo);
+    overflow: hidden;
+  }
+
+  .retro-panel {
+    background: var(--card);
+    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    border-radius: calc(var(--radius) + 2px);
+    box-shadow:
+      0 10px 22px rgba(15, 23, 42, 0.12),
+      inset 1px 1px 0 rgba(255, 255, 255, 0.75),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.10);
+    overflow: hidden;
+  }
+
+  .retro-titlebar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    background: linear-gradient(to bottom, var(--retro-titlebar-top), var(--retro-titlebar-bottom));
+    color: var(--retro-titlebar-text);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
+  }
+
+  .retro-titlebar-title {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    user-select: none;
+  }
+
+  .retro-titlebar-meta {
+    font-size: 0.75rem;
+    opacity: 0.9;
+    user-select: none;
+    white-space: nowrap;
+  }
+
+  .retro-window-body {
+    padding: 1rem;
+    background: var(--card);
+  }
+
+  .retro-menubar {
+    background: linear-gradient(to bottom, var(--retro-titlebar-top), var(--retro-titlebar-bottom));
+    color: var(--retro-titlebar-text);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.28);
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.35);
+    box-shadow:
+      0 14px 35px rgba(15, 23, 42, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  }
+
+  /* Controls */
+  .retro-input {
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.3)) , var(--input);
+    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    border-radius: var(--radius);
+    box-shadow:
+      inset 2px 2px 0 rgba(0, 0, 0, 0.08),
+      inset -2px -2px 0 rgba(255, 255, 255, 0.75);
+  }
+
+  .retro-button {
+    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    border-radius: var(--radius);
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.65),
+      inset 1px 1px 0 rgba(255, 255, 255, 0.7),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.15);
+  }
+
+  .retro-button:active {
+    box-shadow:
+      inset 2px 2px 0 rgba(0, 0, 0, 0.18),
+      inset -2px -2px 0 rgba(255, 255, 255, 0.55);
+    transform: translateY(1px);
+  }
+
+  .retro-button-primary {
+    background: linear-gradient(to bottom, #74b0ff, #2d65f2 55%, #1f4ed6);
+    color: var(--primary-foreground);
+    border-color: color-mix(in srgb, #1f4ed6 70%, black 30%);
+  }
+
+  .retro-button-secondary {
+    background: linear-gradient(to bottom, #ffffff, #dfe7f0 60%, #cfd9e4);
+    color: var(--foreground);
+  }
+
+  .retro-button-ghost {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
+
+  .retro-button-ghost:hover {
+    background: rgba(15, 23, 42, 0.06);
+    border-color: rgba(15, 23, 42, 0.12);
+    box-shadow:
+      inset 1px 1px 0 rgba(255, 255, 255, 0.7),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.08);
+  }
+
+  /* Skeletons: subtle "loading bar" stripes */
+  .retro-skeleton {
+    background:
+      repeating-linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.35) 0px,
+        rgba(255, 255, 255, 0.35) 10px,
+        rgba(0, 0, 0, 0.05) 10px,
+        rgba(0, 0, 0, 0.05) 20px
+      ),
+      var(--muted);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: var(--radius);
+  }
+
+  /* Media frames */
+  .retro-frame {
+    border: 1px solid color-mix(in srgb, var(--border) 75%, white 25%);
+    border-radius: calc(var(--radius) - 2px);
+    box-shadow:
+      inset 1px 1px 0 rgba(255, 255, 255, 0.75),
+      inset -1px -1px 0 rgba(0, 0, 0, 0.14);
+    overflow: hidden;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <ScrollToTopOnNavigation />
         </Suspense>
-        <div className="min-h-screen retro-desktop">
+        <div className="min-h-screen retro-desktop retro-crt">
           <Navbar />
           {children}
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,14 +51,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html
+      lang="en"
+      className={`${inter.variable} ${geistSans.variable} ${geistMono.variable}`}
+    >
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className="subpixel-antialiased"
       >
         <Suspense fallback={null}>
           <ScrollToTopOnNavigation />
         </Suspense>
-        <div className="min-h-screen bg-zinc-50 dark:bg-black">
+        <div className="min-h-screen retro-desktop">
           <Navbar />
           {children}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -111,6 +111,10 @@ export default async function Home() {
               AI-powered recommendations with explanations.
             </p>
           </div>
+          <div className="retro-statusbar">
+            <span>Ready</span>
+            <span className="opacity-80">1024×768 friendly</span>
+          </div>
         </section>
 
         <section className="retro-window">
@@ -129,6 +133,10 @@ export default async function Home() {
             ) : (
               <GamesGrid initialGames={games} />
             )}
+          </div>
+          <div className="retro-statusbar">
+            <span>Tip: Click a game to open</span>
+            <span className="opacity-80">Scroll to load more</span>
           </div>
         </section>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -93,30 +93,44 @@ export default async function Home() {
   const games = await getGames();
 
   return (
-    <main className="flex flex-col gap-8 pt-8">
-      <div className="w-full px-4">
-        <div className="container mx-auto max-w-7xl w-full">
-          <h1 className="text-balance font-semibold tracking-tight text-3xl sm:text-4xl">
-            Find your next favorite indie game
-          </h1>
-        </div>
-      </div>
-
-      {/* Full-width grid section */}
-      <div className="flex flex-col gap-4 w-full px-4 pb-8">
-        <div className="container mx-auto max-w-7xl w-full flex items-center justify-between">
-          <h2 className="font-semibold text-xl">All Games</h2>
-        </div>
-        <div className="container mx-auto max-w-7xl w-full">
-          {games.length === 0 ? (
-            <p className="text-muted-foreground">
-              No games ingested yet. Search for a game above to add your first
-              one.
+    <main className="px-4 py-6 sm:py-8">
+      <div className="container mx-auto max-w-6xl w-full flex flex-col gap-6">
+        <section className="retro-window">
+          <div className="retro-titlebar">
+            <div className="retro-titlebar-title">IndieFindr</div>
+            <div className="retro-titlebar-meta hidden sm:block">
+              Search above to add games to the database
+            </div>
+          </div>
+          <div className="retro-window-body">
+            <h1 className="text-balance font-extrabold tracking-tight text-3xl sm:text-4xl">
+              Find your next favorite indie game
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground max-w-prose">
+              Search any Steam game, instantly jump to its page, and get
+              AI-powered recommendations with explanations.
             </p>
-          ) : (
-            <GamesGrid initialGames={games} />
-          )}
-        </div>
+          </div>
+        </section>
+
+        <section className="retro-window">
+          <div className="retro-titlebar">
+            <div className="retro-titlebar-title">All Games</div>
+            <div className="retro-titlebar-meta">
+              {games.length} in database
+            </div>
+          </div>
+          <div className="retro-window-body">
+            {games.length === 0 ? (
+              <p className="text-muted-foreground">
+                No games ingested yet. Search for a game above to add your first
+                one.
+              </p>
+            ) : (
+              <GamesGrid initialGames={games} />
+            )}
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -119,11 +119,15 @@ function GameCard({
   return (
     <Link
       href={`/games/${appid}`}
-      className="block"
+      className="block group"
       onClick={handleCardClick}
     >
-      <div ref={cardRef}>
-        <div className="relative w-full mb-2 overflow-hidden rounded-md bg-muted aspect-steam">
+      <div
+        ref={cardRef}
+        className="retro-panel transition-[filter,transform] hover:brightness-[1.03]"
+      >
+        <div className="p-3 pb-2">
+          <div className="relative w-full overflow-hidden bg-muted aspect-steam retro-frame">
           {/* Always render image as base layer */}
           {header_image && (
             <Image
@@ -151,13 +155,21 @@ function GameCard({
               onError={() => setVideoError(true)}
             />
           )}
+          {/* Gloss overlay */}
+          <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_bottom,rgba(255,255,255,.55),rgba(255,255,255,0)_55%)] opacity-60" />
         </div>
-        <div className="font-medium text-sm">{title}</div>
+        </div>
+
+        <div className="px-3 pb-3">
+          <div className="font-bold text-sm leading-snug line-clamp-2">
+            {title}
+          </div>
         {explanation && (
-          <div className="text-xs text-muted-foreground first-letter:uppercase">
+          <div className="mt-1 text-xs text-muted-foreground first-letter:uppercase line-clamp-3">
             {explanation}
           </div>
         )}
+        </div>
       </div>
     </Link>
   );

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -126,6 +126,16 @@ function GameCard({
         ref={cardRef}
         className="retro-panel transition-[filter,transform] hover:brightness-[1.03]"
       >
+        <div className="retro-titlebar retro-titlebar--compact">
+          <div className="retro-titlebar-title text-[11px] tracking-wide">
+            GAME_PREVIEW.EXE
+          </div>
+          <div className="retro-window-controls" aria-hidden="true">
+            <span className="retro-dot retro-dot--min" />
+            <span className="retro-dot retro-dot--max" />
+            <span className="retro-dot retro-dot--close" />
+          </div>
+        </div>
         <div className="p-3 pb-2">
           <div className="relative w-full overflow-hidden bg-muted aspect-steam retro-frame">
           {/* Always render image as base layer */}

--- a/src/components/GameVideo.tsx
+++ b/src/components/GameVideo.tsx
@@ -104,7 +104,7 @@ export function GameVideo({
   }, [hasVideo, videoUrl, isHls, startTime]);
 
   return (
-    <div className={`relative overflow-hidden rounded-lg bg-muted ${className}`}>
+    <div className={`relative bg-muted retro-frame ${className}`}>
       {hasVideo && videoUrl ? (
         <video
           ref={videoRef}

--- a/src/components/IngestingDialog.tsx
+++ b/src/components/IngestingDialog.tsx
@@ -28,7 +28,7 @@ export function IngestingDialog({
         </DialogHeader>
         <div className="flex flex-col items-center gap-4 py-4">
           {gameImage && (
-            <div className="relative w-32 h-16 rounded-lg overflow-hidden">
+            <div className="relative w-32 h-16 retro-frame">
               <Image
                 src={gameImage}
                 alt={gameTitle || "Game"}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -184,21 +184,22 @@ export function Navbar() {
         gameTitle={ingestingGame?.title}
         gameImage={ingestingGame?.image}
       />
-      <nav className="sticky top-0 z-50 w-full border-b bg-background">
-        <div className="container mx-auto max-w-4xl flex h-14 items-center gap-3 px-4 w-full">
+      <nav className="sticky top-0 z-50 w-full retro-menubar">
+        <div className="container mx-auto max-w-6xl flex h-14 items-center gap-3 px-4 w-full">
           {/* Logo/Brand */}
           <Link
             href="/"
-            className="flex shrink-0 items-center gap-2 font-bold text-base sm:text-lg"
+            className="flex shrink-0 items-center gap-2 text-base sm:text-lg retro-titlebar-title"
           >
             <Logo />
-            IndieFindr
+            <span>IndieFindr</span>
+            <span className="text-[10px] font-semibold opacity-90">.exe</span>
           </Link>
 
           {/* Search */}
           <div className="relative flex-1" ref={resultsRef}>
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
               <Input
                 type="text"
                 placeholder="Search games..."
@@ -216,7 +217,7 @@ export function Navbar() {
                   type="button"
                   variant="ghost"
                   size="icon"
-                  className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2"
+                  className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 text-slate-700"
                   onClick={() => {
                     setSearchQuery("");
                     setDbResults([]);
@@ -232,7 +233,7 @@ export function Navbar() {
 
             {/* Search Results Dropdown */}
             {showResults && (
-              <div className="fixed left-0 right-0 top-14 z-50 mt-0 max-h-[calc(100vh-3.5rem)] overflow-y-auto border-b bg-background shadow-lg sm:absolute sm:top-full sm:left-0 sm:right-0 sm:mt-1 sm:max-h-96 sm:rounded-md sm:border">
+              <div className="retro-panel fixed left-0 right-0 top-14 z-50 mt-0 max-h-[calc(100vh-3.5rem)] overflow-y-auto sm:absolute sm:top-full sm:left-0 sm:right-0 sm:mt-1 sm:max-h-96">
                 {searchQuery.trim().length < 2 ? (
                   <div className="p-4 text-center text-sm text-muted-foreground">
                     Keep typing to search…
@@ -259,7 +260,7 @@ export function Navbar() {
                                 width={80}
                                 height={48}
                                 sizes="80px"
-                                className="h-12 w-20 object-cover rounded"
+                                className="h-12 w-20 object-cover retro-frame"
                               />
                             )}
                             <span className="flex-1 text-sm font-medium">
@@ -291,7 +292,7 @@ export function Navbar() {
                             width={80}
                             height={48}
                             sizes="80px"
-                            className="h-12 w-20 object-cover rounded"
+                            className="h-12 w-20 object-cover retro-frame"
                           />
                         )}
                         <span className="flex-1 text-sm font-medium">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -196,6 +196,17 @@ export function Navbar() {
             <span className="text-[10px] font-semibold opacity-90">.exe</span>
           </Link>
 
+          {/* Faux menu (purely vibes) */}
+          <div
+            className="hidden md:flex items-center gap-1 text-xs font-semibold tracking-wide opacity-95"
+            aria-hidden="true"
+          >
+            <span className="px-2 py-1 rounded-md hover:bg-white/10">File</span>
+            <span className="px-2 py-1 rounded-md hover:bg-white/10">Edit</span>
+            <span className="px-2 py-1 rounded-md hover:bg-white/10">View</span>
+            <span className="px-2 py-1 rounded-md hover:bg-white/10">Help</span>
+          </div>
+
           {/* Search */}
           <div className="relative flex-1" ref={resultsRef}>
             <div className="relative">
@@ -233,17 +244,27 @@ export function Navbar() {
 
             {/* Search Results Dropdown */}
             {showResults && (
-              <div className="retro-panel fixed left-0 right-0 top-14 z-50 mt-0 max-h-[calc(100vh-3.5rem)] overflow-y-auto sm:absolute sm:top-full sm:left-0 sm:right-0 sm:mt-1 sm:max-h-96">
+              <div className="retro-window fixed left-0 right-0 top-14 z-50 mt-0 max-h-[calc(100vh-3.5rem)] overflow-y-auto sm:absolute sm:top-full sm:left-0 sm:right-0 sm:mt-1 sm:max-h-96">
+                <div className="retro-titlebar retro-titlebar--compact">
+                  <div className="retro-titlebar-title text-xs">
+                    Search Results
+                  </div>
+                  <div className="retro-window-controls" aria-hidden="true">
+                    <span className="retro-dot retro-dot--min" />
+                    <span className="retro-dot retro-dot--max" />
+                    <span className="retro-dot retro-dot--close" />
+                  </div>
+                </div>
                 {searchQuery.trim().length < 2 ? (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
+                  <div className="p-4 text-center text-sm text-muted-foreground bg-card">
                     Keep typing to search…
                   </div>
                 ) : isSearching ? (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
+                  <div className="p-4 text-center text-sm text-muted-foreground bg-card">
                     Searching...
                   </div>
                 ) : dbResults.length > 0 || steamResults.length > 0 ? (
-                  <div className="py-1">
+                  <div className="py-1 bg-card">
                     {/* Database Results */}
                     {dbResults.length > 0 && (
                       <>
@@ -251,7 +272,7 @@ export function Navbar() {
                           <button
                             key={`db-${game.appid}`}
                             onClick={() => handleResultClick(game)}
-                            className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted transition-colors sm:py-2"
+                            className="retro-listitem w-full flex items-center gap-3 px-4 py-3 text-left transition-colors sm:py-2"
                           >
                             {game.header_image && (
                               <Image
@@ -283,7 +304,7 @@ export function Navbar() {
                         key={`steam-${game.appid}`}
                         onClick={() => handleResultClick(game)}
                         disabled={ingestingAppId === game.appid}
-                        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-wait sm:py-2"
+                        className="retro-listitem w-full flex items-center gap-3 px-4 py-3 text-left transition-colors disabled:opacity-50 disabled:cursor-wait sm:py-2"
                       >
                         {game.header_image && (
                           <Image
@@ -311,16 +332,32 @@ export function Navbar() {
                     ))}
                   </div>
                 ) : hasSearched ? (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
+                  <div className="p-4 text-center text-sm text-muted-foreground bg-card">
                     No games found
                   </div>
                 ) : (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
+                  <div className="p-4 text-center text-sm text-muted-foreground bg-card">
                     Searching...
                   </div>
                 )}
               </div>
             )}
+          </div>
+
+          {/* Winamp vibes: tiny EQ + window controls */}
+          <div className="hidden sm:flex items-center gap-3 ml-auto" aria-hidden="true">
+            <div className="retro-eq">
+              <span />
+              <span />
+              <span />
+              <span />
+              <span />
+            </div>
+            <div className="retro-window-controls">
+              <span className="retro-dot retro-dot--min" />
+              <span className="retro-dot retro-dot--max" />
+              <span className="retro-dot retro-dot--close" />
+            </div>
           </div>
         </div>
       </nav>

--- a/src/components/SteamButton.tsx
+++ b/src/components/SteamButton.tsx
@@ -2,7 +2,8 @@
 
 import { track } from "@vercel/analytics";
 import { ArrowUpRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type SteamButtonProps = {
   appid: string;
@@ -18,18 +19,19 @@ export function SteamButton({ appid, title }: SteamButtonProps) {
   };
 
   return (
-    <Button className="w-fit mt-1 sm:mt-0" size="sm">
-      <a
-        href={`https://store.steampowered.com/app/${appid}/`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center gap-1"
-        onClick={handleSteamClick}
-      >
-        <span className="hidden sm:inline">View on Steam</span>
-        <span className="sm:hidden">Steam</span>
-        <ArrowUpRight className="size-3" />
-      </a>
-    </Button>
+    <a
+      href={`https://store.steampowered.com/app/${appid}/`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        buttonVariants({ size: "sm", variant: "default" }),
+        "w-fit mt-1 sm:mt-0"
+      )}
+      onClick={handleSteamClick}
+    >
+      <span className="hidden sm:inline">View on Steam</span>
+      <span className="sm:hidden">Steam</span>
+      <ArrowUpRight className="size-3" />
+    </a>
   );
 }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-const alertVariants = cva("grid gap-0.5 rounded-lg border px-2 py-1.5 text-left text-xs/relaxed has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-1.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-3.5 w-full relative group/alert", {
+const alertVariants = cva("retro-panel grid gap-0.5 px-2 py-1.5 text-left text-xs/relaxed has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-1.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-3.5 w-full relative group/alert", {
   variants: {
     variant: {
       default: "bg-card text-card-foreground",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,24 +4,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium focus-visible:ring-[2px] aria-invalid:ring-[2px] [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "retro-button focus-visible:ring-ring/40 focus-visible:ring-[2px] focus-visible:outline-none aria-invalid:ring-destructive/25 aria-invalid:ring-[2px] aria-invalid:border-destructive dark:aria-invalid:border-destructive/60 bg-clip-padding text-xs/relaxed font-semibold [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-[filter,background-color,color,border-color,box-shadow,transform] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/80",
-        outline: "border-border dark:bg-input/30 hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
-        ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
-        destructive: "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
+        default: "retro-button-primary hover:brightness-105",
+        outline:
+          "retro-button-secondary hover:brightness-105 aria-expanded:brightness-105",
+        secondary:
+          "retro-button-secondary hover:brightness-105 aria-expanded:brightness-105",
+        ghost: "retro-button-ghost",
+        destructive:
+          "retro-button-secondary text-destructive hover:brightness-105 focus-visible:ring-destructive/30",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-7 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        xs: "h-5 gap-1 rounded-sm px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-2.5",
+        xs: "h-5 gap-1 px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-2.5",
         sm: "h-6 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         lg: "h-8 gap-1 px-2.5 text-xs/relaxed has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4",
         icon: "size-7 [&_svg:not([class*='size-'])]:size-3.5",
-        "icon-xs": "size-5 rounded-sm [&_svg:not([class*='size-'])]:size-2.5",
+        "icon-xs": "size-5 [&_svg:not([class*='size-'])]:size-2.5",
         "icon-sm": "size-6 [&_svg:not([class*='size-'])]:size-3",
         "icon-lg": "size-8 [&_svg:not([class*='size-'])]:size-4",
       },

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -11,7 +11,10 @@ function Card({
     <div
       data-slot="card"
       data-size={size}
-      className={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-lg py-4 text-xs/relaxed ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col", className)}
+      className={cn(
+        "retro-panel bg-card text-card-foreground gap-4 py-4 text-xs/relaxed has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col",
+        className
+      )}
       {...props}
     />
   )

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -50,7 +50,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-xs/relaxed ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "retro-window data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 grid max-w-[calc(100%-2rem)] gap-4 p-4 text-xs/relaxed duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
           className
         )}
         {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "bg-input/20 dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-7 rounded-md border px-2 py-0.5 text-sm transition-colors file:h-6 file:text-xs/relaxed file:font-medium focus-visible:ring-[2px] aria-invalid:ring-[2px] md:text-xs/relaxed file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "retro-input focus-visible:ring-ring/40 focus-visible:ring-[2px] aria-invalid:ring-destructive/25 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/60 h-7 px-2 py-0.5 text-sm transition-[box-shadow,border-color,filter] file:h-6 file:text-xs/relaxed file:font-semibold md:text-xs/relaxed file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60",
         className
       )}
       {...props}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-muted rounded-md animate-pulse", className)}
+      className={cn("retro-skeleton animate-pulse", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Redesign the UI with early 2000s web aesthetics, including Winamp, Aqua, and XP cues.

This PR implements a full visual rehaul by updating global CSS variables and base styles to a "desktop + window chrome" theme, applying glossy gradients, beveled panels, and pixel-ish typography. Core UI components (buttons, inputs, cards, dialogs, alerts, skeletons) and key pages (Navbar, GameCard, home, and game detail pages) have been refactored to consistently reflect this retro aesthetic.

---
[Slack Thread](https://thinkhumanco.slack.com/archives/C0A6ST1ELUR/p1767489730369829?thread_ts=1767489730.369829&cid=C0A6ST1ELUR)

<a href="https://cursor.com/background-agent?bcId=bc-7f98e8ed-ce7a-426a-bf77-7cc598f02dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f98e8ed-ce7a-426a-bf77-7cc598f02dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

