### PR TITLE
New game page update

### DIFF
--- a/src/app/games/[appid]/page.tsx
+++ b/src/app/games/[appid]/page.tsx
@@ -3,7 +3,6 @@ import { Suspense, cache } from "react";
 import type { Metadata } from "next";
 import { GameVideo } from "@/components/GameVideo";
 import { SuggestionsListClient } from "@/components/SuggestionsListClient";
-import { SuggestionsSkeleton } from "@/components/SuggestionsSkeleton";
 import { SteamButton } from "@/components/SteamButton";
 import { DevControlBar } from "@/components/DevControlBar";
 import { getSupabaseServerClient } from "@/lib/supabase/server";
@@ -11,6 +10,10 @@ import { GameDetailSkeleton } from "@/components/skeletons/GameDetailSkeleton";
 import { getPinnedCollectionsForGame } from "@/lib/collections";
 import { CollectionsSection } from "@/components/CollectionsSection";
 import { GameProcessingState } from "@/components/GameProcessingState";
+
+// This page needs to reflect newly-ingested rows immediately.
+// Using ISR here can cache the temporary "processing" state and prevent auto-update.
+export const dynamic = "force-dynamic";
 
 type GameData = {
   appid: number;
@@ -477,6 +480,3 @@ export default async function GameDetailPage({
     </main>
   );
 }
-
-// Enable ISR - revalidate every 60 seconds
-export const revalidate = 60;


### PR DESCRIPTION
Stop ISR caching on the game detail page to allow immediate updates for newly ingested games.

The previous ISR caching of the "processing" state prevented the game header and suggestions from updating quickly after a game was ingested, as `router.refresh()` could not reliably bypass the cached "not ready" page.

---
[Slack Thread](https://thinkhumanco.slack.com/archives/C0A6ST1ELUR/p1767567985972639?thread_ts=1767567985.972639&cid=C0A6ST1ELUR)

<a href="https://cursor.com/background-agent?bcId=bc-e54c6870-d065-47b6-bddf-8ba5af76e559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e54c6870-d065-47b6-bddf-8ba5af76e559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

