### PR TITLE
Responsive pinned collection scroll

### DIFF
--- a/src/components/CollectionsSection.tsx
+++ b/src/components/CollectionsSection.tsx
@@ -17,6 +17,9 @@ export function CollectionsSection({
 
   return (
     <div className="flex flex-col gap-8 w-full">
+      <div className="container mx-auto max-w-4xl w-full">
+        <h2 className="font-semibold text-xl">{title}</h2>
+      </div>
       {collections.map((collection) => (
         <div key={collection.id} className="flex flex-col gap-4 w-full">
           <div className="container mx-auto max-w-4xl w-full flex flex-col gap-1">
@@ -48,9 +51,14 @@ export function CollectionsSection({
                 This collection doesn&apos;t have any games yet.
               </p>
             ) : (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-4 md:overflow-visible md:pb-0">
                 {collection.preview_games.map((game) => (
-                  <GameCard key={game.appid} {...game} />
+                  <div
+                    key={game.appid}
+                    className="flex-none w-[240px] sm:w-[260px] md:w-auto"
+                  >
+                    <GameCard {...game} />
+                  </div>
                 ))}
               </div>
             )}

--- a/src/components/skeletons/CollectionsSectionSkeleton.tsx
+++ b/src/components/skeletons/CollectionsSectionSkeleton.tsx
@@ -11,9 +11,12 @@ function CollectionRowSkeleton() {
         <Skeleton className="h-4 w-20" />
       </div>
       <div className="container mx-auto max-w-4xl w-full">
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-4 md:overflow-visible md:pb-0">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-2">
+            <div
+              key={i}
+              className="flex-none w-[240px] sm:w-[260px] md:w-auto flex flex-col gap-2"
+            >
               <Skeleton className="w-full aspect-steam rounded-md" />
               <Skeleton className="h-4 w-3/4" />
             </div>


### PR DESCRIPTION
Implement horizontal scrolling for all pinned collection rows on small screens to improve responsive layout, and add a section header.

The `title` prop in `CollectionsSection` was previously ignored, leading to a lint warning. It is now rendered as a section header to resolve this and provide proper context for the collection.

---
[Slack Thread](https://thinkhumanco.slack.com/archives/C0A6ST1ELUR/p1767590008365959?thread_ts=1767590008.365959&cid=C0A6ST1ELUR)

<a href="https://cursor.com/background-agent?bcId=bc-9b351760-d1e6-47d5-90a0-a170a90b9e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b351760-d1e6-47d5-90a0-a170a90b9e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

