### PR TITLE
Refine cartridge styling

### DIFF
--- a/src/app/collections/[slug]/page.tsx
+++ b/src/app/collections/[slug]/page.tsx
@@ -70,7 +70,7 @@ export default async function CollectionPage({
   const games = await getCollectionGames(collection.id);
 
   return (
-    <main className="flex flex-col gap-8 pt-8">
+    <main className="flex flex-col gap-8">
       <div className="w-full">
         <div className="container mx-auto max-w-4xl w-full">
           <h1 className="text-balance font-semibold tracking-tight text-3xl sm:text-4xl">

--- a/src/app/games/[appid]/page.tsx
+++ b/src/app/games/[appid]/page.tsx
@@ -376,66 +376,71 @@ async function GameContent({ appId, appid }: { appId: number; appid: string }) {
         Games like {gameData.title}
       </h1>
 
-      {/* Trailer Video - Full Width */}
-      {gameData.videos && gameData.videos.length > 0 && (
-        <div className="w-full aspect-video">
-          <GameVideo
-            videos={gameData.videos}
-            headerImage={gameData.header_image}
-            alt={gameData.title}
-            className="w-full h-full"
-          />
-        </div>
-      )}
-
       {/* Game Header */}
-      <div className="flex flex-col gap-4">
-        {/* Title and Description */}
-        <div className="flex flex-col gap-1.5">
-          <div className="text-base sm:text-lg font-semibold leading-tight">
-            {gameData.title}
-          </div>
-          {description && (
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              {truncate(stripHtml(description), 220)}
-            </p>
-          )}
-        </div>
-
-        {/* Inline Metadata - Release, Developers */}
-        {(gameData.release_date || gameData.developers.length > 0) && (
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs sm:text-sm">
-            {gameData.release_date && (
-              <div className="flex items-center gap-1.5">
-                <span className="text-muted-foreground">Release:</span>
-                <span className="text-foreground">{gameData.release_date}</span>
+      <div className="flex flex-col">
+        {/* Trailer Video */}
+        {gameData.videos && gameData.videos.length > 0 && (
+          <div className="mb-6">
+            <div className="cartridge-screen">
+              <div className="cartridge-screen-bezel">
+                <GameVideo
+                  videos={gameData.videos}
+                  headerImage={gameData.header_image}
+                  alt={gameData.title}
+                  className="w-full h-full"
+                />
               </div>
-            )}
-            {gameData.developers.length > 0 && (
-              <div className="flex items-center gap-1.5">
-                <span className="text-muted-foreground">Developer{gameData.developers.length > 1 ? "s" : ""}:</span>
-                <span className="text-foreground">{gameData.developers.join(", ")}</span>
-              </div>
-            )}
+            </div>
           </div>
         )}
+        <div className="px-2 flex flex-col gap-6">
+          <div className="flex flex-col gap-3">
+            {/* Title and Description */}
+            <div className="flex flex-col gap-1">
+              <div className="text-base sm:text-lg font-semibold leading-tight text-[#000000]">
+                {gameData.title}
+              </div>
+              {description && (
+                <p className="text-xs text-[#404040] leading-relaxed">
+                  {truncate(stripHtml(description), 220)}
+                </p>
+              )}
+            </div>
 
-        {/* Steam Button */}
-        <div className="pt-1">
-          <SteamButton appid={appid} title={gameData.title} />
+            {/* Inline Metadata - Release, Developers */}
+            {(gameData.release_date || gameData.developers.length > 0) && (
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+                {gameData.release_date && (
+                  <div className="flex items-center gap-1">
+                    <span className="text-[#404040] font-semibold">RELEASE:</span>
+                    <span className="text-[#000000]">{gameData.release_date}</span>
+                  </div>
+                )}
+                {gameData.developers.length > 0 && (
+                  <div className="flex items-center gap-1">
+                    <span className="text-[#404040] font-semibold">DEV{gameData.developers.length > 1 ? "S" : ""}:</span>
+                    <span className="text-[#000000]">{gameData.developers.join(", ")}</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Steam Button */}
+          <div>
+            <SteamButton appid={appid} title={gameData.title} />
+          </div>
         </div>
       </div>
 
-      {/* Suggestions Section - Nested Suspense */}
-      <div className="flex flex-col gap-3">
-        <div className="flex items-start sm:items-center justify-between gap-3">
-          <h2
-            className="flex-1 min-w-0 text-base sm:text-lg font-semibold leading-snug text-balance line-clamp-2"
-            title={`Games similar to ${gameData.title}`}
-          >
-            Games similar to {gameData.title}
-          </h2>
-        </div>
+      {/* Suggestions Section */}
+      <div className="flex flex-col gap-3 mt-8">
+        <h2
+          className="flex-1 min-w-0 text-base sm:text-lg font-semibold leading-tight text-balance line-clamp-2 text-[#000000]"
+          title={`Games similar to ${gameData.title}`}
+        >
+          Games similar to {gameData.title}
+        </h2>
         <SuggestionsListClient appid={appId} />
       </div>
 
@@ -465,7 +470,7 @@ export default async function GameDetailPage({
   }
 
   return (
-    <main className="container mx-auto max-w-4xl py-6 sm:py-8 flex flex-col gap-3 sm:gap-4">
+    <main className="container mx-auto max-w-4xl pb-6 sm:pb-8 flex flex-col gap-3 sm:gap-4">
       <Suspense
         fallback={
           <GameDetailSkeleton />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: Arial, Helvetica, sans-serif;
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -48,38 +48,38 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.58 0.22 27);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.809 0.105 251.813);
-  --chart-2: oklch(0.623 0.214 259.815);
-  --chart-3: oklch(0.546 0.245 262.881);
-  --chart-4: oklch(0.488 0.243 264.376);
-  --chart-5: oklch(0.424 0.199 265.638);
-  --radius: 0;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --background: oklch(0.98 0 0);
+  --foreground: oklch(0.15 0 0);
+  --card: oklch(0.98 0 0);
+  --card-foreground: oklch(0.15 0 0);
+  --popover: oklch(0.98 0 0);
+  --popover-foreground: oklch(0.15 0 0);
+  --primary: oklch(0.25 0 0);
+  --primary-foreground: oklch(0.98 0 0);
+  --secondary: oklch(0.94 0 0);
+  --secondary-foreground: oklch(0.25 0 0);
+  --muted: oklch(0.94 0 0);
+  --muted-foreground: oklch(0.5 0 0);
+  --accent: oklch(0.94 0 0);
+  --accent-foreground: oklch(0.25 0 0);
+  --destructive: oklch(0.55 0.18 25);
+  --border: oklch(0.88 0 0);
+  --input: oklch(0.88 0 0);
+  --ring: oklch(0.65 0 0);
+  --chart-1: oklch(0.81 0.1 250);
+  --chart-2: oklch(0.62 0.2 260);
+  --chart-3: oklch(0.55 0.25 263);
+  --chart-4: oklch(0.49 0.24 264);
+  --chart-5: oklch(0.42 0.2 266);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.98 0 0);
+  --sidebar-foreground: oklch(0.15 0 0);
+  --sidebar-primary: oklch(0.25 0 0);
+  --sidebar-primary-foreground: oklch(0.98 0 0);
+  --sidebar-accent: oklch(0.94 0 0);
+  --sidebar-accent-foreground: oklch(0.25 0 0);
+  --sidebar-border: oklch(0.88 0 0);
+  --sidebar-ring: oklch(0.65 0 0);
 }
 
 .dark {
@@ -120,11 +120,525 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    background: linear-gradient(to bottom,
+      #1a1a1a 0%,
+      #222222 50%,
+      #1c1c1c 100%
+    );
+    background-attachment: fixed;
+    min-height: 100%;
+    overscroll-behavior: none;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    font-family: Arial, Helvetica, sans-serif;
+    background: linear-gradient(to bottom,
+      #1a1a1a 0%,
+      #222222 50%,
+      #1c1c1c 100%
+    );
+    background-attachment: fixed;
+    min-height: 100vh;
+    overscroll-behavior: none;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-family: Arial, Helvetica, sans-serif;
   }
 }
 
 .aspect-steam {
   aspect-ratio: 460 / 215;
+}
+
+/* Glassmorphic Win95 Background */
+@supports (backdrop-filter: blur(10px)) {
+  .win95-glass-bg {
+    background: rgba(192, 192, 192, 0.7);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+  }
+}
+
+/* Retro Game Cartridge Style - REFINED */
+.cartridge {
+  background: linear-gradient(to bottom, 
+    #dadada 0%, 
+    #d2d2d2 50%,
+    #cacaca 100%
+  );
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: 
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  overflow: hidden;
+  position: relative;
+  padding: 6px;
+  transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s ease;
+}
+
+.cartridge:hover {
+  transform: translateY(-2px);
+  box-shadow: 
+    0 4px 12px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.cartridge:active {
+  transform: translateY(0);
+  box-shadow: 
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    inset 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.cartridge-label {
+  aspect-ratio: 460 / 215;
+  background: #000;
+  position: relative;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: inset 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
+.cartridge-divider-line {
+  height: 1px;
+  background: linear-gradient(to right,
+    transparent 0%,
+    rgba(0, 0, 0, 0.08) 20%,
+    rgba(0, 0, 0, 0.12) 50%,
+    rgba(0, 0, 0, 0.08) 80%,
+    transparent 100%
+  );
+  margin: 0;
+}
+
+.cartridge-body {
+  background: transparent;
+  position: relative;
+}
+
+.cartridge-pins {
+  height: 3px;
+  background: linear-gradient(to bottom, 
+    #707070 0%,
+    #505050 100%
+  );
+  position: relative;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  margin-top: auto;
+}
+
+.cartridge-pin-row {
+  height: 1px;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.15) 0px,
+    rgba(0, 0, 0, 0.15) 3px,
+    rgba(0, 0, 0, 0.08) 3px,
+    rgba(0, 0, 0, 0.08) 6px
+  );
+  margin: 0.5px 6px;
+}
+
+/* Cartridge Console Navbar */
+.cartridge-console {
+  background: rgba(220, 220, 220, 0.85);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  box-shadow: 
+    0 1px 4px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+
+/* Cartridge Slot (Search Input) */
+.cartridge-slot {
+  background: transparent;
+}
+
+.cartridge-slot-inset {
+  background: transparent;
+  position: relative;
+}
+
+.win95-input {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  outline: none;
+  box-shadow: 
+    inset 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.win95-input:focus {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 
+    inset 0 1px 3px rgba(0, 0, 0, 0.1),
+    0 0 0 2px rgba(0, 0, 0, 0.05);
+}
+
+.cartridge-eject-button {
+  background: rgba(200, 200, 200, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: all 0.15s ease;
+}
+
+.cartridge-eject-button:hover {
+  background: rgba(210, 210, 210, 1);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transform: translateY(-0.5px);
+}
+
+.cartridge-eject-button:active {
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  transform: translateY(0);
+}
+
+/* Cartridge Tray (Search Results) */
+.cartridge-tray {
+  background: rgba(250, 250, 250, 0.95);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  box-shadow: 
+    0 10px 25px rgba(0, 0, 0, 0.15),
+    0 4px 10px rgba(0, 0, 0, 0.08);
+  padding: 4px;
+}
+
+.cartridge-result-item {
+  background: transparent;
+  border-radius: 6px;
+  transition: all 0.12s ease;
+  position: relative;
+}
+
+.cartridge-result-item:hover {
+  background: oklch(0.25 0 0);
+}
+
+.cartridge-result-item:hover span {
+  color: #ffffff !important;
+  text-shadow: none;
+}
+
+.cartridge-divider {
+  height: 1px;
+  background: rgba(0, 0, 0, 0.06);
+  margin: 4px 0;
+}
+
+/* Console Background */
+.cartridge-console-bg {
+  background: #fdfdfd;
+  position: relative;
+}
+
+.cartridge-console-bg::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: 
+    radial-gradient(circle at 20% 30%, rgba(100, 50, 200, 0.02) 0%, transparent 50%),
+    radial-gradient(circle at 80% 70%, rgba(200, 100, 50, 0.02) 0%, transparent 50%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.console-screen {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  background: #f8f8f8;
+}
+
+/* Cartridge Reader (Game Detail Header) */
+.cartridge-reader {
+  background: #f2f2f2;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+  box-shadow: 
+    0 20px 50px rgba(0, 0, 0, 0.08),
+    0 5px 15px rgba(0, 0, 0, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 1);
+  overflow: hidden;
+  position: relative;
+}
+
+.cartridge-reader-label {
+  background: #1a1a1a;
+  padding: 8px 16px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.cartridge-reader-label-text {
+  color: #ffcc00;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  text-align: center;
+  font-family: 'Courier New', monospace;
+  opacity: 0.9;
+}
+
+.cartridge-screen {
+  background: linear-gradient(to bottom, 
+    #dadada 0%, 
+    #d2d2d2 50%,
+    #cacaca 100%
+  );
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 
+    0 2px 8px rgba(0, 0, 0, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  overflow: hidden;
+  position: relative;
+  padding: 8px;
+}
+
+.cartridge-screen-bezel {
+  aspect-ratio: 16 / 9;
+  position: relative;
+  background: #000;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: inset 0 2px 12px rgba(0, 0, 0, 0.6);
+}
+
+.cartridge-screen-reflection {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 40%;
+  background: linear-gradient(to bottom,
+    rgba(255, 255, 255, 0.1) 0%,
+    transparent 100%
+  );
+  pointer-events: none;
+  z-index: 10;
+}
+
+.cartridge-reader-body {
+  background: linear-gradient(to bottom,
+    rgba(255, 255, 255, 0.4) 0%,
+    rgba(255, 255, 255, 0.2) 100%
+  );
+}
+
+.cartridge-metadata {
+  background: rgba(255, 255, 255, 0.6);
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+/* Cartridge Library Section */
+.cartridge-library {
+  background: #f9f9f9;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 16px;
+  box-shadow: 
+    0 10px 40px rgba(0, 0, 0, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 1);
+  overflow: hidden;
+}
+
+.cartridge-library-header {
+  background: #2a2a2a;
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.cartridge-library-label {
+  background: #000;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+.cartridge-library-label-text {
+  color: #00ff00;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  font-family: 'Courier New', monospace;
+  opacity: 0.8;
+}
+
+.cartridge-library-content {
+  padding: 24px;
+}
+
+/* Console Title Screen */
+.console-title-screen {
+  background: #f2f2f2;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 16px;
+  box-shadow: 
+    0 10px 40px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 1);
+  padding: 32px;
+  text-align: center;
+}
+
+.console-title-label {
+  background: #1a1a1a;
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  display: inline-block;
+  margin-bottom: 16px;
+}
+
+.console-title-label-text {
+  color: #ffcc00;
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  font-family: 'Courier New', monospace;
+  opacity: 0.9;
+}
+
+/* Cartridge Action Button */
+.cartridge-action-button {
+  background: #ffcc00;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 
+    0 2px 6px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.3);
+  transition: all 0.2s cubic-bezier(0.23, 1, 0.32, 1);
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.cartridge-action-button:hover {
+  background: #ffd633;
+  box-shadow: 
+    0 6px 15px rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transform: translateY(-2px);
+}
+
+.cartridge-button-pressed {
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+  transform: translateY(1px);
+}
+
+/* Win95 Style Bevels - REFINED */
+.win95-card {
+  background: rgba(240, 240, 240, 0.8);
+  backdrop-filter: blur(30px) saturate(180%);
+  -webkit-backdrop-filter: blur(30px) saturate(180%);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 
+    0 15px 40px rgba(0, 0, 0, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.win95-card-pressed {
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.win95-bevel-inset {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(10px);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+/* Win95 Button */
+.win95-button {
+  background: rgba(245, 245, 245, 0.9);
+  backdrop-filter: blur(10px);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+  transition: all 0.2s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.win95-button:hover {
+  background: #ffffff;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1.5px);
+}
+
+.win95-button-pressed {
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.05);
+  transform: translateY(0.5px);
+}
+
+/* Win95 Input */
+.win95-input {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05);
+  transition: all 0.2s ease;
+}
+
+.win95-input:focus {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 
+    inset 0 1px 3px rgba(0, 0, 0, 0.08),
+    0 0 0 3px rgba(0, 0, 0, 0.03);
+}
+
+/* Win95 Input */
+.win95-input {
+  background: linear-gradient(to bottom, 
+    #e8e8e8 0%,
+    #e0e0e0 50%,
+    #d8d8d8 100%
+  );
+  border: 2px inset;
+  border-top-color: rgba(128, 128, 128, 0.85);
+  border-left-color: rgba(128, 128, 128, 0.85);
+  border-bottom-color: rgba(255, 255, 255, 0.85);
+  border-right-color: rgba(255, 255, 255, 0.85);
+  border-radius: 6px;
+  outline: none;
+  box-shadow: 
+    inset 0 1px 2px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.win95-input:focus {
+  border-top-color: rgba(128, 128, 128, 0.85);
+  border-left-color: rgba(128, 128, 128, 0.85);
+  border-bottom-color: rgba(255, 255, 255, 0.85);
+  border-right-color: rgba(255, 255, 255, 0.85);
+  background: linear-gradient(to bottom, 
+    #f0f0f0 0%,
+    #e8e8e8 50%,
+    #e0e0e0 100%
+  );
+  box-shadow: 
+    inset 0 1px 2px rgba(0, 0, 0, 0.2);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,10 +59,12 @@ export default function RootLayout({
         <Suspense fallback={null}>
           <ScrollToTopOnNavigation />
         </Suspense>
-        <div className="min-h-screen bg-zinc-50 dark:bg-black">
+        <div className="min-h-screen cartridge-console-bg dark:bg-black">
           <Navbar />
-          <div className="px-4">
-            {children}
+          <div className="console-screen pt-14 px-4">
+            <div className="container mx-auto max-w-4xl pb-8">
+              {children}
+            </div>
           </div>
         </div>
         <Toaster />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,14 +87,10 @@ export default async function Home() {
   }
 
   return (
-    <main className="flex flex-col gap-8 pt-8">
-      <div className="w-full">
-        <div className="container mx-auto max-w-4xl w-full">
-          <h1 className="text-balance font-semibold tracking-tight text-3xl sm:text-4xl">
-            Find your next favorite indie game
-          </h1>
-        </div>
-      </div>
+    <main className="flex flex-col gap-8">
+      <h1 className="text-balance font-semibold text-2xl sm:text-3xl text-[#000000]">
+        Find your next favorite indie game
+      </h1>
 
       {/* Pinned Collections Section */}
       {pinnedCollections.length > 0 && (
@@ -102,20 +98,16 @@ export default async function Home() {
       )}
 
       {/* Full-width grid section */}
-      <div className="flex flex-col gap-4 w-full">
-        <div className="container mx-auto max-w-4xl w-full flex items-center justify-between">
-          <h2 className="font-semibold text-xl">All Games</h2>
-        </div>
-        <div className="container mx-auto max-w-4xl w-full">
-          {games.length === 0 ? (
-            <p className="text-muted-foreground">
-              No games ingested yet. Search for a game above to add your first
-              one.
-            </p>
-          ) : (
-            <GamesGrid initialGames={games} />
-          )}
-        </div>
+      <div className="flex flex-col gap-4">
+        <h2 className="font-semibold text-lg text-[#000000]">All Games</h2>
+        {games.length === 0 ? (
+          <p className="text-[#404040] text-sm">
+            No games ingested yet. Search for a game above to add your first
+            one.
+          </p>
+        ) : (
+          <GamesGrid initialGames={games} />
+        )}
       </div>
     </main>
   );

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -12,13 +12,13 @@ export function CollectionCard({ collection }: CollectionCardProps) {
   return (
     <Link
       href={`/collections/${slug}`}
-      className="block rounded-lg border bg-card p-4 transition-colors hover:bg-accent"
+      className="win95-card block group hover:translate-y-[-2px] transition-transform duration-200"
     >
-      <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 p-2">
         <div>
-          <h3 className="font-semibold text-lg leading-tight">{title}</h3>
+          <h3 className="font-semibold text-base leading-tight group-hover:underline">{title}</h3>
           {description && (
-            <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+            <p className="mt-1 text-[10px] text-[#404040] line-clamp-2">
               {description}
             </p>
           )}
@@ -26,11 +26,11 @@ export function CollectionCard({ collection }: CollectionCardProps) {
 
         {/* Preview games grid */}
         {preview_games.length > 0 && (
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-3 gap-1.5">
             {preview_games.map((game) => (
               <div
                 key={game.appid}
-                className="relative aspect-steam overflow-hidden rounded-md bg-muted"
+                className="relative aspect-steam overflow-hidden rounded-sm bg-muted border border-black/5"
               >
                 {game.header_image && (
                   <Image
@@ -48,7 +48,7 @@ export function CollectionCard({ collection }: CollectionCardProps) {
               Array.from({ length: 3 - preview_games.length }).map((_, i) => (
                 <div
                   key={`empty-${i}`}
-                  className="aspect-steam rounded-md bg-muted"
+                  className="aspect-steam rounded-sm bg-muted/50 border border-black/5"
                 />
               ))}
           </div>

--- a/src/components/CollectionsSection.tsx
+++ b/src/components/CollectionsSection.tsx
@@ -18,43 +18,41 @@ export function CollectionsSection({
   return (
     <div className="flex flex-col gap-8 w-full">
       {collections.map((collection) => (
-        <div key={collection.id} className="flex flex-col gap-4 w-full">
-          <div className="container mx-auto max-w-4xl w-full flex flex-col gap-1">
+        <div key={collection.id} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
             <div className="flex items-baseline gap-2">
               <Link
                 href={`/collections/${collection.slug}`}
-                className="font-semibold text-xl hover:underline"
+                className="font-semibold text-lg text-[#000000] hover:underline"
               >
                 {collection.title}
               </Link>
               {(collection.total_games_count ?? collection.preview_games.length) > 4 && (
                 <Link
                   href={`/collections/${collection.slug}`}
-                  className="text-sm text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
+                  className="text-xs text-[#404040] hover:text-[#000000] transition-colors whitespace-nowrap"
                 >
                   View all →
                 </Link>
               )}
             </div>
             {collection.description && (
-              <p className="text-sm text-muted-foreground">
+              <p className="text-xs text-[#404040]">
                 {collection.description}
               </p>
             )}
           </div>
-          <div className="container mx-auto max-w-4xl w-full">
-            {collection.preview_games.length === 0 ? (
-              <p className="text-muted-foreground">
-                This collection doesn&apos;t have any games yet.
-              </p>
-            ) : (
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {collection.preview_games.map((game) => (
-                  <GameCard key={game.appid} {...game} />
-                ))}
-              </div>
-            )}
-          </div>
+          {collection.preview_games.length === 0 ? (
+            <p className="text-[#404040] text-sm">
+              This collection doesn&apos;t have any games yet.
+            </p>
+          ) : (
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {collection.preview_games.map((game) => (
+                <GameCard key={game.appid} {...game} />
+              ))}
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useState, useEffect, useRef } from "react";
 import { track } from "@vercel/analytics";
+import { cn } from "@/lib/utils";
 import type { GameCardGame } from "@/lib/supabase/types";
 
 type GameCardProps = GameCardGame & {
@@ -20,6 +21,7 @@ function GameCard({
   const [videoError, setVideoError] = useState(false);
   const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
   const [videoReady, setVideoReady] = useState(false);
+  const [isPressed, setIsPressed] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
   const hasVideo = videos?.length > 0 && !videoError;
@@ -148,9 +150,23 @@ function GameCard({
   };
 
   return (
-    <Link href={`/games/${appid}`} className="block" onClick={handleCardClick}>
-      <div ref={cardRef}>
-        <div className="relative w-full mb-2 overflow-hidden rounded-md bg-muted aspect-steam">
+    <Link
+      href={`/games/${appid}`}
+      className="block h-full"
+      onClick={handleCardClick}
+    >
+      <div
+        ref={cardRef}
+        className={cn(
+          "cartridge h-full flex flex-col group transition-all duration-150 ease-out",
+          isPressed && "cartridge-button-pressed translate-y-0.5"
+        )}
+        onMouseDown={() => setIsPressed(true)}
+        onMouseUp={() => setIsPressed(false)}
+        onMouseLeave={() => setIsPressed(false)}
+      >
+        {/* Label area */}
+        <div className="cartridge-label relative overflow-hidden mb-2">
           {/* Always render image as base layer */}
           {header_image && (
             <Image
@@ -180,13 +196,39 @@ function GameCard({
               onError={() => setVideoError(true)}
             />
           )}
+          {/* Inset shadow overlay */}
+          <div
+            className="absolute inset-0 w-full h-full pointer-events-none"
+            style={{
+              boxShadow: "inset 0 4px 12px rgba(0, 0, 0, 0.4)",
+            }}
+          />
+          {/* Inner bevel */}
+          <div
+            className="absolute inset-0 w-full h-full pointer-events-none"
+            style={{
+              border: "1px solid",
+              borderTopColor: "rgba(0, 0, 0, 0.1)",
+              borderLeftColor: "rgba(0, 0, 0, 0.1)",
+              borderBottomColor: "rgba(255, 255, 255, 0.05)",
+              borderRightColor: "rgba(255, 255, 255, 0.05)",
+            }}
+          />
         </div>
-        <div className="font-medium text-sm">{title}</div>
-        {explanation && (
-          <div className="text-xs text-muted-foreground first-letter:uppercase">
-            {explanation}
+
+        {/* Divider */}
+        <div className="cartridge-divider-line" />
+
+        <div className="cartridge-body flex-1 flex flex-col justify-start w-full px-1 pt-1.5 pb-1">
+          <div className="font-bold text-xs text-[#000000] mb-1 leading-tight">
+            {title}
           </div>
-        )}
+          {explanation && (
+            <div className="text-[10px] text-[#404040] first-letter:uppercase leading-tight">
+              {explanation}
+            </div>
+          )}
+        </div>
       </div>
     </Link>
   );

--- a/src/components/GameVideo.tsx
+++ b/src/components/GameVideo.tsx
@@ -104,7 +104,7 @@ export function GameVideo({
   }, [hasVideo, videoUrl, isHls, startTime]);
 
   return (
-    <div className={`relative overflow-hidden rounded-lg bg-muted ${className}`}>
+    <div className={`relative overflow-hidden bg-muted ${className}`} style={{ borderRadius: '6px', border: '1px solid', borderTopColor: 'rgba(0, 0, 0, 0.1)', borderLeftColor: 'rgba(0, 0, 0, 0.1)', borderBottomColor: 'rgba(255, 255, 255, 0.05)', borderRightColor: 'rgba(255, 255, 255, 0.05)' }}>
       {hasVideo && videoUrl ? (
         <video
           ref={videoRef}
@@ -113,6 +113,7 @@ export function GameVideo({
           loop={loop}
           playsInline
           className="w-full h-full object-cover"
+          style={{ borderRadius: '4px' }}
           onError={() => {
             setVideoError(true);
           }}
@@ -123,13 +124,15 @@ export function GameVideo({
           alt={alt}
           fill
           className="object-cover"
+          style={{ borderRadius: '4px' }}
           sizes="100vw"
         />
       ) : (
-        <div className="w-full h-full bg-muted flex items-center justify-center">
+        <div className="w-full h-full bg-muted flex items-center justify-center" style={{ borderRadius: '4px' }}>
           <span className="text-muted-foreground text-sm">No preview available</span>
         </div>
       )}
+      <div className="absolute inset-0 w-full h-full pointer-events-none" style={{ borderRadius: '4px', boxShadow: 'inset 0 4px 12px rgba(0, 0, 0, 0.4)' }} />
     </div>
   );
 }

--- a/src/components/GamesGrid.tsx
+++ b/src/components/GamesGrid.tsx
@@ -59,7 +59,7 @@ export function GamesGrid({ initialGames }: GamesGridProps) {
 
   return (
     <>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 auto-rows-fr">
         {games.map((game) => (
           <GameCard key={game.appid} {...game} />
         ))}

--- a/src/components/SteamButton.tsx
+++ b/src/components/SteamButton.tsx
@@ -2,7 +2,7 @@
 
 import { track } from "@vercel/analytics";
 import { ArrowUpRight } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { useState } from "react";
 
 type SteamButtonProps = {
   appid: string;
@@ -10,6 +10,8 @@ type SteamButtonProps = {
 };
 
 export function SteamButton({ appid, title }: SteamButtonProps) {
+  const [isPressed, setIsPressed] = useState(false);
+  
   const handleSteamClick = () => {
     track("steam_page_click", {
       appid,
@@ -18,18 +20,19 @@ export function SteamButton({ appid, title }: SteamButtonProps) {
   };
 
   return (
-    <Button className="w-fit mt-1 sm:mt-0" size="sm">
-      <a
-        href={`https://store.steampowered.com/app/${appid}/`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="flex items-center gap-1"
-        onClick={handleSteamClick}
-      >
-        <span className="hidden sm:inline">View on Steam</span>
-        <span className="sm:hidden">Steam</span>
-        <ArrowUpRight className="size-3" />
-      </a>
-    </Button>
+    <a
+      href={`https://store.steampowered.com/app/${appid}/`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`cartridge-action-button inline-flex items-center gap-1.5 px-4 py-2 text-xs font-semibold text-[#000000] ${isPressed ? "cartridge-button-pressed" : ""}`}
+      onClick={handleSteamClick}
+      onMouseDown={() => setIsPressed(true)}
+      onMouseUp={() => setIsPressed(false)}
+      onMouseLeave={() => setIsPressed(false)}
+    >
+      <span className="hidden sm:inline">VIEW ON STEAM</span>
+      <span className="sm:hidden">STEAM</span>
+      <ArrowUpRight className="size-3.5" />
+    </a>
   );
 }

--- a/src/components/SuggestionsSkeleton.tsx
+++ b/src/components/SuggestionsSkeleton.tsx
@@ -25,10 +25,10 @@ export function SuggestionsSkeleton({
       )}
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
         {Array.from({ length: count }).map((_, index) => (
-          <div key={index} className="flex flex-col">
-            <Skeleton className="w-full aspect-steam mb-2" />
+          <div key={index} className="win95-card flex flex-col gap-2 p-3">
+            <Skeleton className="w-full aspect-steam rounded-sm" />
             <Skeleton className="h-4 w-3/4" />
-            <Skeleton className="h-3 w-full mt-2" />
+            <Skeleton className="h-3 w-full" />
           </div>
         ))}
       </div>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -11,7 +11,7 @@ function Card({
     <div
       data-slot="card"
       data-size={size}
-      className={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-lg py-4 text-xs/relaxed ring-1 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg group/card flex flex-col", className)}
+      className={cn("win95-card flex flex-col", className)}
       {...props}
     />
   )
@@ -22,7 +22,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "gap-1 rounded-t-lg px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+        "gap-1 px-4 py-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Introduce a modern-retro console theme (global CSS tokens + root layout screen container).
- Refine game card and video presentation to match the cartridge look (bevels, backgrounds, spacing).
- Align home, collection, and game detail pages (and skeletons) with consistent layout and spacing.

## Test plan
- Run `pnpm dev`.
- Visit home and scroll/overscroll to confirm no white background flash.
- Open a game detail page and verify video container styling matches game cards.
- Visit a collection page and verify cards/grid spacing.

## Original branch
This is a clean-history rewrite of [`refine-cartridge-styling`](https://github.com/btn0s/games-graph/tree/refine-cartridge-styling).