### PR TITLE
Home page title change

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteUrl =
     process.env.NEXT_PUBLIC_SITE_URL || "https://www.indiefindr.gg";
   const canonicalUrl = `${siteUrl}/`;
-  const title = "Find Your Next Favorite Indie Game — IndieFindr";
+  const title = "TEST";
   const description =
     "Discover indie games on Steam. Search any game, get AI-powered recommendations, and find your next favorite.";
   const ogImageUrl = `${siteUrl}/og/home.png`;
@@ -90,7 +90,7 @@ export default async function Home() {
       <div className="w-full">
         <div className="container mx-auto max-w-4xl w-full">
           <h1 className="text-balance font-semibold tracking-tight text-3xl sm:text-4xl">
-            Find your next favorite indie game
+            TEST
           </h1>
         </div>
       </div>


### PR DESCRIPTION
Update the home page's browser/SEO title and visible `<h1>` heading to "TEST".

---
<a href="https://cursor.com/background-agent?bcId=bc-f8250342-9bca-432f-968b-f23bf7edde0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8250342-9bca-432f-968b-f23bf7edde0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

