### PR TITLE
Game suggestion query enhancement

### DIFF
--- a/src/lib/suggest.ts
+++ b/src/lib/suggest.ts
@@ -30,8 +30,13 @@ export async function suggestGames(
   console.log("[SUGGEST] Starting search");
 
   const basePrompt = `Based on this image${
-    text ? ` and the following context: "${text}"` : ""
-  }, find Steam games that are similar to what you see.
+    text ? ` and the following context:\n\n${text}\n` : ""
+  }\nfind Steam games that are similar to what you see.
+
+SEARCH STRATEGY (important for new/obscure games):
+- Do NOT rely only on the game's title. Use the Steam metadata + keyword hints in the context to infer genre, mechanics, and vibe.
+- Use the suggested search queries (if provided) as starting points to dig for similar games, even when the title has limited coverage online.
+- Prioritize matching on mechanics, perspective, art direction, pacing, and tone over exact name similarity.
 
 Return 8-12 similar Steam games as a JSON array. Use this EXACT format (no markdown, no code fences, just raw JSON):
 


### PR DESCRIPTION
Enhance game suggestion generation with richer Steam metadata and explicit search strategies to improve results for new or low-signal games.

Previously, game suggestions relied primarily on the game's title and descriptions, leading to poor results for new or less popular games with limited online presence. This change provides the AI with structured Steam metadata (genres, categories, developer, publisher, keywords) and a set of pre-generated, diverse search queries, enabling it to 'dig' for better suggestions even when the title alone is insufficient.

---
<a href="https://cursor.com/background-agent?bcId=bc-77bb1b2f-e27c-4ac9-bcc8-a434152435f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-77bb1b2f-e27c-4ac9-bcc8-a434152435f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

