### PR TITLE
Game suggestion query enhancement

### DIFF
--- a/src/lib/ingest.ts
+++ b/src/lib/ingest.ts
@@ -347,11 +347,29 @@ function buildTextContext(
   return [title, shortDesc, longDesc].filter(Boolean).join(". ");
 }
 
+function decodeBasicHtmlEntities(text: string): string {
+  // Minimal decoding to keep prompts readable without adding dependencies.
+  return text
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#34;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
 function stripHtml(input: string): string {
-  return input
-    .replace(/<[^>]*>/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  const withoutTags = input
+    // Convert common line breaks to newlines first.
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    .replace(/<\s*\/p\s*>/gi, "\n")
+    // Then strip remaining tags.
+    .replace(/<[^>]*>/g, " ");
+
+  const decoded = decodeBasicHtmlEntities(withoutTags);
+  return decoded.replace(/\s+/g, " ").trim();
 }
 
 function truncate(input: string, maxLen: number): string {

--- a/src/lib/suggest.ts
+++ b/src/lib/suggest.ts
@@ -30,8 +30,13 @@ export async function suggestGames(
   console.log("[SUGGEST] Starting search");
 
   const basePrompt = `Based on this image${
-    text ? ` and the following context: "${text}"` : ""
+    text ? ` and the following context:\n${text}\n` : ""
   }, find Steam games that are similar to what you see.
+
+SEARCH STRATEGY (IMPORTANT):
+- Do NOT rely on a single generic query like "games like <title>".
+- Use the provided Steam metadata + keywords to form multiple diverse search queries (genres, Steam categories, developer/publisher, release window, and any standout gameplay keywords).
+- Prefer queries that surface under-the-radar indies (e.g., "indie <genre> co-op games", "new indie <genre> games <year>", "<keyword1> <keyword2> indie games on Steam").
 
 Return 8-12 similar Steam games as a JSON array. Use this EXACT format (no markdown, no code fences, just raw JSON):
 


### PR DESCRIPTION
Add query expansion to Perplexity suggestions to improve results for games with limited description data.

This PR generates smarter, more diverse search queries using Steam metadata (genres, categories, developers, publishers, release date) and keywords extracted from descriptions, providing Perplexity with a richer context than just "games like <title>". This helps in surfacing better suggestions for newer or less-documented games.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3314e55-945e-4593-b765-974e2b05b288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3314e55-945e-4593-b765-974e2b05b288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

