### PR TITLE
docs: add experiment plan for LLM-free suggestion serving

### DIFF
--- a/docs/interaction-trained-recommender.md
+++ b/docs/interaction-trained-recommender.md
@@ -1,0 +1,223 @@
+# Interaction-trained recommender: design + bootstrap plan
+
+Part 2 of the [LLM-free suggestions experiment plan](./llm-free-suggestions-experiment-plan.md). Part 1 attacks **cost** (LLM off the request path). This doc attacks **latency and ceiling**: replace per-request generation with a **traditional item-item recommender** — learned embeddings, precomputed neighbors, millisecond serving — and solve the no-users cold-start by **manufacturing interaction data** with a purpose-built labeling task ("the trainer") run by LLM agents and, when available, real users.
+
+The mental model: today the LLM *is* the recommender, run at request time (slow, expensive, stochastic). Here the LLM becomes a **data annotator** that runs in batches, and the recommender is a small vector model that never thinks at serve time.
+
+---
+
+## 1. Target architecture
+
+### Serving (hot path — no LLM, no network, no generation)
+
+```
+game page request
+  → SELECT precomputed neighbors FROM game_suggestions (or pgvector top-K)
+  → render. ~5ms.
+```
+
+- Every game has a learned **similarity embedding** in `game_vibes.vibe_embedding` (pgvector, already provisioned with `find_similar_vibes`).
+- A nightly job materializes top-K neighbors per game into `game_suggestions`, so the request path is a plain indexed read — the existing UI in `suggestions-section.tsx` doesn't change shape, the "generating…" state just disappears.
+- **Explanations** are no longer generated per request: template them from shared signals ("Both cozy pixel-art farming sims", "Same developer", "Loved by the same players") at materialization time. If templated reasons feel flat, one cached LLM-written sentence per *promoted pair* is a bounded one-time cost, not a serving cost.
+
+### The model (two towers, so cold start stays solved)
+
+Pure collaborative filtering can't place a game with zero interactions — fatal for a discovery site that ingests new indies constantly. So:
+
+```
+item embedding e(g) = f_θ(content(g)) + r_g
+```
+
+- `content(g)`: fixed feature vector — text-embedding of title+description, weighted tag vector, **structured facet annotations (§1.5)**, developer hash, review ratio, log-owners. Computed once at ingest (Part 1, E2 infrastructure).
+- `f_θ`: small learned projection (linear or 1-hidden-layer MLP) from content space into **similarity space**. This is what training fits.
+- `r_g`: per-game residual, regularized toward zero, only learned for games with enough interaction evidence. New game → `r_g = 0` → it's placed purely by content through `f_θ`, which has *absorbed* the interaction signal. Cold start inherits everything the model learned.
+
+Similarity = cosine in this space. Train with **triplet/BPR loss** on judgments: for seed `s`, picked `p`, shown-but-not-picked `n`:
+
+```
+loss = −log σ( e(s)·e(p) − e(s)·e(n) )
+```
+
+This is a few thousand parameters — trainable in seconds in a `tsx` script with no ML framework, checkpointed as JSON in the repo. Re-embedding the catalog after training is one matrix multiply per game.
+
+### 1.5 Manufacturing the missing taste metadata (the facet problem)
+
+The whole reason the custom multi-strategy system exists: **raw Steam sources don't carry taste/gameplay-feel data.** Tags say "Roguelike, Pixel Graphics"; nothing says *whimsical vs punishing*, *meditative vs frantic*, or that "cannons" here means charming pirates, not a shooter. The current pipeline compensates by having LLMs re-derive this per request. The recommender keeps the faceted insight but moves the derivation to **one-time, cached enrichment**:
+
+1. **Facet annotation at ingest (one LLM call per game, ever).** Persist what `detectGameType` computes and throws away today, but richer — a structured record per game:
+
+   ```jsonc
+   // games_new.facets (JSONB), written once at ingest, versioned by prompt
+   {
+     "type": "cozy",                       // the existing GameType taxonomy
+     "vibe": ["whimsical", "serene"],      // controlled vocabulary, not freeform
+     "mechanics": ["deckbuilder", "base-building"],
+     "pacing": "relaxed",                   // relaxed | moderate | frantic
+     "tone": "lighthearted",                // controlled list
+     "session_length": "short",
+     "complexity": "low",
+     "facet_version": "v1"
+   }
+   ```
+
+   Controlled vocabularies (not freeform text) make these one-hot/embedding features for `content(g)`. Cost: ~$0.0005/game with a cheap model → the whole catalog plus every future ingest is dollars, total — versus re-deriving it on every page view.
+
+2. **Review-text mining (free taste signal).** Steam review *text* is where players already say "cozy", "brutal but fair", "feels like Outer Wilds". Batch-extract facet mentions from the top ~30 reviews per game (cheap NLP keyword pass first; LLM extraction only where reviews are rich) and merge into the same facet record with a `source` marker. Also harvest explicit "feels like X" / "if you liked Y" mentions as **direct similarity pairs** for Source A.
+
+3. **Facet-aware similarity, preserving the multi-strategy idea.** "Similar" isn't one scalar — the current system's vibe/mechanics/community split is real signal. Carry it through with **multi-head embeddings**: `f_θ` outputs 2–3 small sub-vectors (vibe head, mechanics head), and the serving score is a type-weighted combination — `getWeightsForType` reborn, but with weights *fit by E4/E8* instead of hand-tuned, and per-facet spaces trained on facet-labeled triplets (§2.4).
+
+---
+
+## 2. Interaction data: three sources, one schema
+
+### 2.1 Schema (impressions logged, per the eval framework's Layer D)
+
+```sql
+create table judgment_sessions (
+  id uuid primary key default gen_random_uuid(),
+  source text not null,            -- 'human' | 'agent'
+  agent_model text,                -- e.g. 'gpt-4o-mini'
+  persona_id text,                 -- for agents; null for humans
+  created_at timestamptz default now()
+);
+
+create table similarity_judgments (
+  id bigserial primary key,
+  session_id uuid references judgment_sessions(id),
+  seed_appid bigint not null,
+  shown_appids bigint[] not null,  -- the full impression set (critical: enables
+                                   -- unbiased eval + propensity correction later)
+  picked_appids bigint[] not null, -- "feels similar"
+  best_appid bigint,               -- optional single strongest pick
+  rejected_appids bigint[] not null default '{}', -- explicit "definitely not"
+  facet text,                      -- null = overall similarity; 'vibe' | 'mechanics'
+                                   -- when the screen asked a facet-specific question
+  sampler_version text not null,   -- how candidates were chosen (see 2.4)
+  latency_ms integer,              -- humans: trap for rubber-stamping
+  created_at timestamptz default now()
+);
+```
+
+One screen → one row → up to `picked × (shown − picked)` training triplets, plus hard negatives from `rejected_appids`. Ten seconds of human attention yields ~10–30 triplets.
+
+### 2.2 Source A — Mined Steam co-engagement (free, real, do first)
+
+Before paying anyone (agent or human) to *imitate* taste, mine actual taste:
+
+- Steam's public reviews endpoint (`appreviews`) returns reviewer IDs per game. Reviewers with public profiles expose their other reviews. **Games co-reviewed by the same people** is the classic "players also liked" signal — exactly what commercial recommenders run on.
+- Pipeline: rate-limited crawler (reuse `acquireRateLimit` from `steamspy.ts` patterns) → co-review count matrix over the catalog → PMI weighting (so co-occurrence with mega-hits doesn't dominate) → these pairs become high-weight positive triplets, or directly an item2vec-style pretraining corpus.
+- Caveats: slow crawl (days, fine — it's free), only covers games with review volume (obscure indies stay content-only — that's what the content tower is for), respect private profiles and rate limits.
+
+This grounds the embedding space in real human behavior at zero labeling cost. Trainer data then *corrects and refines* it rather than carrying everything.
+
+### 2.3 Source B — Agent trainer runs (volume, cheap, must be calibrated)
+
+A CLI (`scripts/trainer/run-agents.ts`) replays the exact same task a human would see:
+
+- Input per call: seed game (title, description, tags) + 8 candidates (same fields), persona spec.
+- One **cheap model** call (e.g. gpt-4o-mini with structured output: `{picked: [], best, rejected: []}`) ≈ $0.0005. **100k judgments ≈ $50**, generated overnight, with a hard budget flag on the CLI.
+- Personas matter less than diversity of seeds/candidates, but keep 5–10 fixed persona specs ("cozy-only player", "mechanics purist", "art-game connoisseur") so the data doesn't collapse to one taste.
+- **Calibration gate (same discipline as Part 1's judge):** before any bulk run, agents and a human label the **same ~100 screens**; require agreement (picked-set overlap) above a threshold (e.g. mean Jaccard ≥ 0.5, and near-zero disagreement on `rejected`). Agents that fail get prompt iteration against the human labels — never against model performance.
+- Agent rows keep `source='agent'` forever, so training can down-weight them (start at 0.3× human weight) or drop them in ablations.
+
+### 2.4 Source C — Human trainer (highest value per label, smallest volume)
+
+A `/trainer` route (or local-only page) — deliberately game-like and fast:
+
+- Show seed (header image + one line) and a 4×2 grid of candidate cards. Tap all that "feel similar to this", optional long-press for "best", swipe/X for "definitely not". Submit → next seed. Target < 10s per screen.
+- **Candidate sampling is the experiment design** (and is versioned via `sampler_version`): each screen mixes
+  - 3–4 current-model top picks (confirm/deny the model),
+  - 2 **hard negatives** — high tag overlap but suspected vibe clash (the exact failure mode the LLM pipeline was good at catching; this is where human labels are worth the most),
+  - 1–2 exploration picks (popularity-matched random) so the space gets coverage and the data isn't hopelessly biased toward the model's existing beliefs.
+- **Facet-conditioned screens:** most screens ask plain "feels similar?"; a rotating fraction (~20%) asks a facet-specific question — "which of these *feels* like it?" vs "which of these *plays* like it?" — recorded in `facet`. These train the multi-head spaces (§1.5.3) so the model keeps the vibe/mechanics distinction the current system encodes by hand. Agents get the same split.
+- You alone doing 15 min/day ≈ 90 screens/day ≈ ~2k triplets/day. Friends/early users multiply that. Every label also doubles as eval ground truth.
+
+---
+
+## 3. Training loop (the "trainer run")
+
+All offline, all CLI, each run prints its label counts and dollar cost:
+
+```
+scripts/trainer/
+  mine-steam-coreviews.ts   # Source A crawler → similarity_judgments (source='steam')
+  run-agents.ts             # Source B batch labeling, --budget-usd cap
+  train.ts                  # triplets → fit f_θ (+ residuals) → weights JSON artifact
+  embed-catalog.ts          # apply f_θ to all games → game_vibes.vibe_embedding
+  materialize.ts            # pgvector top-K per game → game_suggestions + templated reasons
+  evaluate.ts               # Part 1 harness: judge/scorecard vs frozen baselines
+```
+
+Cadence: retrain when new labels accumulate or scorecard drifts — explicitly, never per-request. Each `train.ts` output is a versioned artifact; `materialize.ts` only promotes an artifact that passed `evaluate.ts` gates (Part 1 §5 decision rules apply unchanged).
+
+---
+
+## 4. Experiments (continuing Part 1's numbering and protocol)
+
+Same fixtures: gold seed set, frozen E0 baseline, calibrated judge, holdout discipline.
+
+### E6 — Co-engagement mining
+
+- **Hypothesis:** PMI-weighted co-review similarity alone beats tag cosine (E1) on mid-popularity seeds, and embeddings pretrained on it beat content-only embeddings (E2) overall.
+- **Method:** crawl → build co-review pairs → (a) raw PMI neighbor lists as an algo, (b) triplets pretraining `f_θ`. Judge both vs E1/E2 artifacts on holdout seeds.
+- **Risks measured:** coverage (% of catalog with ≥ N co-review pairs), popularity bias (scorecard `popularity_skew`).
+
+### E7 — Agent-fidelity gate
+
+- **Hypothesis:** a cheap-model agent can reproduce human similarity picks well enough to be a volume label source.
+- **Method:** 100 shared screens, you + 3 agent configs (model × prompt). Metric: picked-set Jaccard vs human, rejected-set agreement. **Pre-registered gate:** best config ≥ 0.5 mean Jaccard, else agents are demoted to pretraining-only data.
+- **Spend:** < $1. Run before any bulk agent labeling.
+
+### E8 — Learning curve (the headline experiment)
+
+- **Hypothesis:** slate quality rises with triplet count and saturates within an affordable label budget.
+- **Method:** fix the model; train on nested subsets — 0 (content-only prior) / 2k / 10k / 50k / 100k triplets (agent-generated, post-E7) — evaluate each on holdout with the judge. Plot win-rate-vs-baseline against label count.
+- **Decision value:** tells you whether the trainer concept works *at all*, what labels cost to reach parity, and where to stop spending. If the curve is flat, the bottleneck is features or task design, not volume — stop and diagnose, don't scale.
+
+### E9 — Human/agent ablation
+
+- **Hypothesis:** small-human + large-agent mixed training beats either source alone on a **human-labeled** holdout.
+- **Method:** train three variants (human-only ~2k, agent-only ~50k, mixed with agent down-weighting); same holdout. Also ablate Source A in/out.
+- **Outcome:** the actual data recipe, with evidence.
+
+### E10 — Cold-start regression gate (ship blocker)
+
+- **Hypothesis:** new games placed by content tower alone (`r_g = 0`) get slates no worse than E2's content-kNN.
+- **Method:** hold out 30 games *entirely* from training (no triplets, no co-review pairs); embed via `f_θ` only; judge their slates vs E2. **Gate:** non-inferior, since every freshly ingested game lives in this state.
+
+### E11 — Facet-feature ablation (does manufactured metadata earn its keep?)
+
+- **Hypothesis:** adding the one-time LLM facet annotations (§1.5) to `content(g)` measurably beats raw tags+description embeddings — i.e. the facet insight behind the custom system survives the move to cheap serving. Secondary: multi-head facet embeddings beat a single similarity scalar on the seed types where the hand-tuned weights differ most (avant-garde, competitive).
+- **Method:** train identical models on identical triplets with content towers of (a) tags+text only, (b) +facet annotations, (c) +facet annotations with multi-head output and type-weighted scoring. Judge on holdout, per-type slices.
+- **Decision value:** if (a) ≈ (b), skip the enrichment pipeline entirely; if (b) or (c) wins, the per-game annotation call becomes a permanent, justified part of ingest. This directly tests whether the faceted system's value lives in the *metadata* (cheap to keep) or in per-request LLM reasoning (expensive to keep).
+- **Spend:** ~$2 annotations backfill + ~$2 judge.
+
+### E12 — End-to-end bakeoff and promotion
+
+- Winner of the E8/E9/E11 recipe, materialized via the full pipeline (train → embed → materialize), judged vs the frozen E0 LLM baseline on holdout seeds, per-type slices reported.
+- **Promotion rule:** Part 1 §5 unchanged (win+tie ≥ 45%, hard gates on must-not/vibe-conflict, avant-garde slice gets the curated/audit fallback if it lags). Plus a new latency claim to verify honestly: p95 serve time from `game_suggestions` read, which should be ~3 orders of magnitude below the current generate path.
+
+### Sequencing and budget
+
+| Order | Item | Blocked by | Est. spend |
+|---|---|---|---|
+| 1 | Schema + trainer CLI skeleton | Part 1 infra | $0 |
+| 2 | **E6** co-review mining + pretraining | 1 | $0 (time) |
+| 3 | **E7** agent fidelity gate | 1 | < $1 |
+| 4 | Human trainer route, start daily labeling | 1 | $0 |
+| 5 | **E8** learning curve | 3 | ~$10–50 (agent labels) |
+| 6 | **E9** ablation | 4, 5 | ~$5 |
+| 7 | **E10** cold-start gate | 5 | ~$1 (judge) |
+| 8 | **E11** facet-feature ablation | 5 | ~$4 |
+| 9 | **E12** bakeoff + promotion | 6, 7, 8 | ~$2 (judge) |
+
+Worst case ≈ **$75 total** to find out whether a trained item-item recommender can replace the per-request LLM pipeline — roughly the cost of E0's baseline measurement of the current system.
+
+---
+
+## 5. What this buys beyond cost
+
+- **Latency:** suggestions render with the page; the skeleton/"generating" state and SSE polling for suggestions become dead code.
+- **Determinism:** same seed → same slate between retrains; run-to-run stability stops being a metric we have to monitor.
+- **Compounding asset:** every trainer session, agent run, and mined co-review permanently improves a model **you own**, instead of being burned in a one-off generation. The current pipeline's entire historical `game_suggestions` output also gets recycled as weak positives (Part 1, E3) — the money already spent becomes training data.
+- **A real flywheel for later:** the impression-logged judgment schema is exactly the structure needed when real user signals (clicks, saves, "not this vibe") arrive — they append to the same table with `source='user_implicit'` and the same trainer consumes them. The bootstrap path and the production learning path are one system.

--- a/docs/llm-free-suggestions-experiment-plan.md
+++ b/docs/llm-free-suggestions-experiment-plan.md
@@ -6,6 +6,7 @@ LLM spend becomes **bounded and offline**: one-time per-game enrichment at inges
 
 **Related docs**
 
+- [Interaction-trained recommender (Part 2)](./interaction-trained-recommender.md) — the follow-on plan: traditional item-item recommender trained on bootstrapped interaction data (trainer task, agent + human labeling, co-review mining), experiments E6–E11.
 - [Recommendation evaluation framework](./recommendation-evaluation-framework.md) — the eval stack (pairwise human eval, scorecard, gold set) these experiments plug into.
 - [Case study](./case-study-suggestion-system.md) — how the current pipeline evolved.
 - [`scripts/experiments-v2/`](../scripts/experiments-v2/README.md) — previous round (prompt variants; all still LLM-serving). This plan is the successor.

--- a/docs/llm-free-suggestions-experiment-plan.md
+++ b/docs/llm-free-suggestions-experiment-plan.md
@@ -1,0 +1,201 @@
+# Experiment plan: LLM-free suggestion serving
+
+**Goal:** serve "games like X" slates with **zero LLM calls on the request path**, at quality statistically indistinguishable from (or acceptably close to) the current pipeline — verified by controlled experiments, not vibes.
+
+LLM spend becomes **bounded and offline**: one-time per-game enrichment at ingest, plus explicit CLI training/eval runs with a fixed budget. Production serving is pure Postgres.
+
+**Related docs**
+
+- [Recommendation evaluation framework](./recommendation-evaluation-framework.md) — the eval stack (pairwise human eval, scorecard, gold set) these experiments plug into.
+- [Case study](./case-study-suggestion-system.md) — how the current pipeline evolved.
+- [`scripts/experiments-v2/`](../scripts/experiments-v2/README.md) — previous round (prompt variants; all still LLM-serving). This plan is the successor.
+
+---
+
+## 1. Why: cost anatomy of the current pipeline
+
+### Cost per suggestion run
+
+One call to `suggestGamesVibe` ([`src/lib/suggest.ts`](../src/lib/suggest.ts)) makes:
+
+| Stage | Model | Calls (best case) | Calls (worst case) |
+|---|---|---|---|
+| Type detection | `openai/gpt-4o-mini` | 1 | 1 |
+| 3 strategies (vibe/mechanics/community) | `perplexity/sonar` | 3 | 9 (each retries ×3 on parse failure) |
+| Per-strategy retry if < 3 results | `perplexity/sonar` | 0 | +9 |
+| Full-pipeline retry if consensus < 4 | `perplexity/sonar` | 0 | +9–18 |
+| Curation | `openai/gpt-4o-mini` | 1 | 1 |
+
+So **5 calls best case, ~20–35 worst case**. Perplexity Sonar is search-grounded and charges a per-request search fee on top of tokens, so it dominates: roughly $0.005–0.01/call → **~$0.02–0.30+ per slate** depending on retry amplification. The gpt-4o-mini calls are noise by comparison.
+
+### Why cost scales with zero users
+
+Two structural amplifiers:
+
+1. **Page-view trigger.** [`suggestions-section.tsx`](../src/app/games/%5Bappid%5D/suggestions-section.tsx) auto-submits `generateSuggestions` for any game page with no `game_suggestions` rows. Any visitor — including **crawlers and prefetchers** — fires a full pipeline run.
+2. **Ingest fan-out.** Each slate inserts ~10 suggested games; up to `MAX_AUTO_INGEST` (6) missing ones are auto-ingested with `skipSuggestions=true` — but their pages then auto-trigger their own runs on first view (see 1). Each generation of the crawl frontier multiplies spend: 1 submitted game → ~6 new pages → ~36 → …
+
+**Cost model:** `spend = runs/day × cost/run`, where `runs/day` is driven by bot traffic over the auto-ingested frontier, and `cost/run` is inflated by retry amplification. Experiments below attack `cost/run → ~0` on the request path; §7 lists immediate stop-the-bleed fixes for `runs/day` that don't need experiments.
+
+---
+
+## 2. Core hypothesis and non-goals
+
+**H0 (core):** A retrieval + scoring algorithm over data we already store (Steam tags, descriptions, developers, reviews, one-time embeddings) can produce slates that human/judge pairwise eval rates at parity with the LLM pipeline for most seed types, at ≤ 1% of the marginal cost and with deterministic, instant serving.
+
+**H1 (training):** Where hand-tuned scoring falls short, we can *distill* the LLM pipeline's judgment into the cheap algorithm: use LLM-as-judge and the accumulated `game_suggestions` corpus as training labels for a small learned scorer, trained offline via CLI. The LLM teaches; it doesn't serve.
+
+**Expected weak spot (state it up front):** avant-garde/art games. Tag and embedding similarity will likely under-perform the Perplexity community-search strategy for the weird stuff. The experiments measure this slice explicitly rather than hiding it in an average; the fallback is a curated/manual path for that slice, not LLM-per-request for everyone.
+
+**Non-goals:** personalization, taste briefs, online A/B (no traffic to power them). This is strictly seed → slate, evaluated offline per the eval framework.
+
+---
+
+## 3. Shared infrastructure (build once, before any experiment)
+
+All experiments share the same fixtures so results are comparable.
+
+### 3.1 Gold seed set (`scripts/eval/gold-seeds.json`)
+
+~60 seeds, **stratified**, frozen and versioned in git:
+
+- 10 per `GameType` (avant-garde, cozy, competitive, narrative, action, mainstream) — type assigned by hand, not by `detectGameType`, so type-detection errors don't contaminate the eval.
+- Within each type, mix popularity tiers (mega-hit / mid / obscure by SteamSpy owners).
+- Include known failure-mode seeds from the case study (e.g. whimsical-game-gets-shooters).
+- Split **by seed**: 40 train / 20 holdout. Holdout seeds are never used for weight fitting or prompt iteration. Per-type holdout slices are small (~3 seeds), so treat per-type holdout numbers as smoke signals; use the train set with cross-validation for per-type conclusions.
+
+Each row uses the eval-case template from the framework doc (`must_match`, `must_not`, `acceptable_surprise`).
+
+### 3.2 Runner CLI (`scripts/eval/run.ts`)
+
+```
+npx tsx scripts/eval/run.ts --algo <name> --seeds gold-seeds.json --repeat 3 --out runs/<timestamp>-<algo>.json
+```
+
+- `--algo` selects a **suggester function** with one shared signature: `(seed: GameNew, k: number) => Promise<Slate>`. The current pipeline is registered as `llm-baseline`; every candidate registers alongside it.
+- Output artifact per run: seed, slate (appids + reasons), per-stage timing, **counted API calls and estimated $** (instrument `generateText` with a wrapper that tallies calls/tokens — this is also how Experiment 0 measures the baseline honestly), and diagnostics (consensus, verified rate where applicable).
+- Deterministic algos run `--repeat 1`; stochastic ones `--repeat 3` so we can report run-to-run stability (mean pairwise Jaccard between repeats of the same seed).
+
+### 3.3 Automatic scorecard (`scripts/eval/score.ts`)
+
+Cheap, deterministic metrics over a run artifact — no LLM, runnable on every commit:
+
+| Metric | Source |
+|---|---|
+| `tag_similarity_mean` / `min` | `calculateTagSimilarity` in [`src/lib/utils/steamspy.ts`](../src/lib/utils/steamspy.ts) |
+| `vibe_conflict_rate` | `hasVibeConflict` (horror↔wholesome etc.) |
+| `must_not_violation_rate` | gold-seed `must_not` lists, keyed to tags |
+| `popularity_skew` | median SteamSpy owners of slate vs seed tier |
+| `redundancy` | same-franchise / same-dev duplicates per slate |
+| `self_or_dlc_rate` | slate contains seed, its DLC, or its soundtrack |
+| `catalog_coverage` | % of slate already in `games_new` (proxy for fan-out cost) |
+| `stability` | Jaccard across repeats |
+| `cost_per_slate_usd`, `p95_latency_ms` | from runner instrumentation |
+
+The scorecard is a **guardrail**, not the optimization target (Goodhart). Promotion decisions use pairwise judgment (3.4); the scorecard catches regressions cheaply between judge runs.
+
+### 3.4 Pairwise judge (`scripts/eval/judge.ts`) — calibrated before trusted
+
+- LLM judge compares two **blinded, order-randomized** slates for the same seed using the rubric in the framework doc (fit / constraints / discovery / coherence; explanations judged separately since non-LLM algos produce templated reasons). Judge prompt and model are **frozen and versioned**; changing them invalidates cross-run comparisons.
+- **Calibration experiment (gate):** before any algo comparison, collect ~50 human pairwise labels (you, via a tiny CLI that shows two slates and asks "which, or tie"). Compute judge–human agreement. **Gate: ≥ 70% agreement on non-ties.** If the judge fails, iterate on the judge prompt against the *human labels* (never against algo results), or fall back to human-only labeling for headline numbers.
+- Judge cost is the experiment budget: ~60 seeds × ~$0.002–0.01/comparison ≈ **$0.50–1 per full bakeoff**. That's the entire recurring LLM spend of this program.
+
+---
+
+## 4. The experiments
+
+Each follows the same protocol: **hypothesis → independent variable (one thing changes) → fixed gold set → metrics → pre-registered success criteria → decision.**
+
+### Experiment 0 — Baseline measurement (no changes, just truth)
+
+*You can't claim improvement without knowing where you are.*
+
+- **Questions:** What does the current pipeline actually cost per slate? How stable is it run-to-run? What's its scorecard profile per seed type? And in production: what triggers runs?
+- **Method:**
+  1. Run `llm-baseline` over all 60 gold seeds, `--repeat 3`. Record cost/slate distribution (incl. retry amplification frequency), latency, stability, scorecard.
+  2. **Self-consistency check:** judge repeat-run pairs against each other. If the pipeline beats *itself* in ~50/50 with low Jaccard, its output is high-variance — which loosens how big a win any challenger needs to show, and is itself a finding.
+  3. Add a `trigger` column/log to every production `suggestGamesVibe` call (`ingest` / `page_view` / `manual_refresh`) and tally a week of data to confirm the bot-traffic hypothesis from §1.
+- **Deliverable:** baseline run artifact (frozen; all later experiments compare against it) + one-page cost report.
+- **Estimated spend:** 180 pipeline runs ≈ $5–50 depending on retry behavior — the most expensive experiment in this plan, and it only runs once.
+
+### Experiment 1 — Tag-vector similarity (zero AI anywhere)
+
+- **Hypothesis:** weighted Steam tag overlap + simple priors reaches parity for mainstream/cozy/competitive/action seeds.
+- **Algorithm (`tags-v1`):** score every candidate in `games_new` by weighted tag cosine (SteamSpy tag weights or position-weighted store tags via `tagsArrayToRecord`), plus a same-developer bonus, indie prior (penalize mega-owners when seed is small), review-ratio floor, and hard `hasVibeConflict` filter. Pure SQL/TS; no network calls at serve time.
+- **Prerequisite:** backfill `steamspy_tags` for all of `games_new` (columns exist since migration `20260108000002`; one rate-limited batch script) and fetch tags at ingest going forward.
+- **Known limitation:** candidates come only from `games_new` (currently suggestion-fan-out biased). Run a catalog-size sensitivity check — score slates with the catalog artificially halved — to estimate how much quality depends on catalog breadth, and expand ingestion (e.g. top-N indie tags crawl) if it's the bottleneck.
+- **Success criteria:** judge win+tie ≥ 45% vs `llm-baseline` overall (non-inferiority, see §5) **and** ≥ 45% on every non-avant-garde slice; `must_not_violation_rate` ≤ baseline.
+- **Spend:** ~$1 (judge only).
+
+### Experiment 2 — Embedding kNN (AI once per game, amortized)
+
+- **Hypothesis:** one-time embeddings capture the "vibe" that raw tags miss (tone words in descriptions), closing most of the gap on narrative/cozy seeds.
+- **Algorithm (`embed-v1`):** embed `title + short_description + top tags` with a small embedding model (~$0.02 per 1k games — one-time); store in the existing `game_vibes.vibe_embedding` pgvector column; serve via the existing `find_similar_vibes` SQL function + the same filters as `tags-v1`. New games get embedded inside `ingest()` — one cheap call per game, ever.
+- **Variant (`embed-v2`, only if v1 promising):** embed an LLM-written one-paragraph vibe summary (the `game_vibes.vibe_summary` column was built for exactly this) instead of raw description — one gpt-4o-mini call per game at ingest, still amortized.
+- **Success criteria:** same non-inferiority gate as E1; additionally beats `tags-v1` head-to-head on narrative+cozy slices (otherwise tags win on simplicity and E2 is dropped).
+- **Spend:** ~$1 embeddings backfill + ~$1 judge.
+
+### Experiment 3 — Learned reranker, distilled from the LLM ("training runs")
+
+This is the train-offline / serve-cheap centerpiece.
+
+- **Hypothesis:** a small learned model over hand-crafted features recovers most of the LLM pipeline's curation judgment.
+- **Features per (seed, candidate):** tag cosine, embedding cosine, shared-developer, review ratio, log-owners gap, release-era gap, seed-type one-hot × each (so weights can vary by type), vibe-conflict flag.
+- **Labels (distillation, all generated offline via CLI):**
+  - *Weak positives:* accumulated `game_suggestions` rows — the LLM pipeline's historical output, already paid for. Negatives: random catalog games matched on popularity tier.
+  - *Preference labels:* for the 40 training seeds, have the frozen judge rank candidate pools → pairwise preferences.
+- **Model:** logistic regression first (a weight vector you can read and ship as JSON); gradient-boosted trees only if LR clearly underfits. Serving = retrieve top-200 by embedding/tags, apply the weight vector. Still zero LLM calls.
+- **Protocol:** fit on train seeds, evaluate on the 20 holdout seeds the model has never seen. Report overfit gap (train vs holdout win rate). Retraining is an explicit CLI run with a printed dollar cost, run when the catalog or scorecard drifts — not on a schedule, never per-request.
+- **Success criteria:** beats the best of E1/E2 on holdout judge win rate; overall win+tie vs `llm-baseline` ≥ 50%.
+- **Spend:** ~$2–5 (judge labeling of training pools + final bakeoff).
+
+### Experiment 4 — Black-box weight tuning (cheap optimizer, LLM fitness)
+
+- **Hypothesis:** even without a learned model, directly optimizing E1/E2's hand-built score weights (per `GameType`, like `getWeightsForType` does today) against judged quality beats hand-tuning.
+- **Method:** grid or CMA-ES over the weight vector; fitness = scorecard composite on train seeds with periodic judge spot-checks (full judge fitness on every candidate is affordable but slow; the scorecard pre-screens). Evaluate winner on holdout.
+- **Run order note:** E4 is cheaper than E3 and shares its infrastructure — run it first if E1/E2 come close to the gate and just need tuning; skip straight to E3 if they miss badly.
+- **Spend:** ~$1–3.
+
+### Experiment 5 — Hybrid: cheap serving + budget-capped LLM audit
+
+Only if a pure-cheap winner has a stubborn bad slice (likely avant-garde).
+
+- **Hypothesis:** quality of the worst slates improves materially when a nightly batch job re-curates only the bottom decile by scorecard, under a hard monthly budget cap.
+- **Method:** serve everything from the cheap algorithm; a cron CLI ranks slates by scorecard, sends the worst N to the existing LLM curation (or replaces them with manually curated lists for known art-game clusters — `KNOWN_ARTGAME_DEVS` already enumerates them), writes results back to `game_suggestions`. Requests never wait on an LLM.
+- **Success criteria:** avant-garde slice win rate recovers to within tolerance, with audited spend ≤ the cap (e.g. $5/month).
+
+---
+
+## 5. Decision rules (pre-registered)
+
+- **Headline metric:** pairwise win+tie rate vs the frozen E0 baseline artifact, judged by the calibrated judge, on holdout seeds.
+- **Non-inferiority, not superiority:** the challenger doesn't need to *beat* the LLM pipeline; given a ~100–1000× cost reduction and instant serving, **win+tie ≥ 45%** (i.e. losing slightly is acceptable) promotes — *except* `must_not_violation_rate` and `vibe_conflict_rate` must be ≤ baseline (hard gate, per the framework's ship-blocker rule).
+- **Slices over averages:** report every metric per `GameType`. A challenger that's great on average but craters avant-garde ships **with** E5's audit path or a curated fallback for that slice — never silently.
+- **Sample-size honesty:** with 20 holdout seeds, win-rate differences under ~20 points aren't significant (binomial; at 20 trials the 95% CI on a proportion is roughly ±20 points). Treat 45% vs 55% as a tie; use the human-label batch to break real ties. Don't run 10 variants and pick the luckiest (multiple comparisons).
+- **Promotion = flip one call site.** All three production triggers funnel through `suggestGamesVibe`; the winner replaces it behind the same signature, with the LLM pipeline kept registered in the eval CLI as the reference baseline.
+
+## 6. Sequencing and budget
+
+| Order | Item | Blocked by | Est. LLM spend |
+|---|---|---|---|
+| 1 | §7 stop-the-bleed fixes | — | $0 (saves money) |
+| 2 | Infra: gold set, runner, scorecard | — | $0 |
+| 3 | Judge calibration vs ~50 human labels | 2 | ~$1 |
+| 4 | **E0** baseline measurement | 2 | $5–50 (once) |
+| 5 | Tag backfill + **E1** | 4 | ~$1 |
+| 6 | Embedding backfill + **E2** | 4 | ~$2 |
+| 7 | **E4** weight tuning (if E1/E2 are close) | 5/6 | ~$2 |
+| 8 | **E3** learned reranker (if needed) | 5/6 | ~$5 |
+| 9 | **E5** hybrid audit (if a slice lags) | promotion | capped, ~$5/mo |
+
+Total experimental budget: **on the order of $20–70, mostly E0** — i.e. less than the production pipeline plausibly burns in days of bot traffic today.
+
+## 7. Stop-the-bleed (do immediately; orthogonal to the experiments)
+
+These don't change the algorithm, so they need no experiment — just guardrails:
+
+1. **Kill the page-view trigger for bots:** don't auto-submit generation from `SuggestionsLoader`; require a user gesture (button) or at minimum skip known bot user-agents, and rate-limit `generateSuggestions` per IP like `/api/games/submit` already is.
+2. **Never regenerate silently:** if a completed run exists for an appid (any age), serve it; regeneration only via explicit refresh.
+3. **Cap retry amplification:** move `MIN_HIGH_CONSENSUS` full-pipeline retry and per-strategy retries behind a single max-total-Sonar-calls budget per run (e.g. 6) in `src/lib/config.ts`.
+4. **Pause `autoIngestMissingGames` fan-out** beyond depth 1 from a user-submitted game (tag auto-ingested rows and don't auto-generate suggestions for their pages).
+5. **Log `trigger` + cost per run** (also needed for E0) so the bleed is visible on a dashboard, not in an invoice.

--- a/scripts/trainer/README.md
+++ b/scripts/trainer/README.md
@@ -1,0 +1,39 @@
+# Trainer: interaction data collection + training
+
+Implements the bootstrap loop from
+[`docs/interaction-trained-recommender.md`](../../docs/interaction-trained-recommender.md):
+collect similarity judgments (humans, agents, mined Steam co-reviews), fit a
+cheap scorer offline, serve with zero LLM calls.
+
+## Prerequisites
+
+- Migration `20260613000000_add_similarity_judgments.sql` applied
+  (`pnpm supabase:reset` locally or push to the linked project).
+- `steamspy_tags` populated for the catalog — the sampler and trainer score by
+  tags. Games without tags are skipped.
+- `SUPABASE_SERVICE_ROLE_KEY` in `.env.local` (all writes use the service
+  client; the new tables have no public RLS policies).
+
+## Pieces
+
+| What | How |
+|---|---|
+| Human labeling UI | `/trainer` route — gated by `TRAINER_ENABLED=true`, unindexed. One tap = similar, two = definitely not. ~20% of screens ask facet-specific questions (feel vs play). |
+| Agent labeling | `npx tsx scripts/trainer/run-agents.ts --screens 20 --budget-usd 0.50` — cheap model plays the same task across fixed personas; hard budget cap; rows tagged `source='agent'`. |
+| Steam co-review mining | `npx tsx scripts/trainer/mine-steam-coreviews.ts --limit 50` — resumable crawl of public review pages; stores hashed reviewer→game edges. |
+| Co-review pairs | `npx tsx scripts/trainer/refresh-coreview-pairs.ts` — rebuilds PMI-weighted `coreview_pairs` from edges and prints the top pairs as a sanity check. |
+| Training | `npx tsx scripts/trainer/train.ts` — BPR over (seed, picked, not-picked) pairs; linear weights over tag/dev/review/popularity features; split **by seed** for honest holdout; writes a JSON artifact to `scripts/trainer/artifacts/`. |
+
+## Gates before scaling (from the experiment plan)
+
+- **E7 agent fidelity:** before bulk `run-agents` spending, label ~100 screens
+  yourself at `/trainer`, run agents over the *same period of seeds*, and
+  compare picked-set agreement. Down-weight (`--agent-weight`) or exclude agent
+  data if agreement is poor.
+- **E8 learning curve:** retrain at increasing judgment counts and watch
+  holdout pairwise accuracy; if it's flat, fix features or task design before
+  buying more labels.
+
+The trainer prints a tag-similarity-only holdout accuracy alongside the
+learned weights — that's the E1 baseline; the learned model has to beat it to
+justify existing.

--- a/scripts/trainer/mine-steam-coreviews.ts
+++ b/scripts/trainer/mine-steam-coreviews.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Source A: mine Steam co-review edges for the catalog.
+ *
+ * For each game in games_new, fetches public review pages from Steam's
+ * appreviews endpoint and stores (appid, hashed reviewer id) edges.
+ * Co-occurrence of the same reviewer across two catalog games is the
+ * "players also liked" signal; refresh-coreview-pairs.ts turns edges
+ * into PMI-weighted pairs.
+ *
+ * Resumable: games that already have edges are skipped unless --refresh.
+ *
+ * Usage:
+ *   npx tsx scripts/trainer/mine-steam-coreviews.ts [--limit 50] [--pages 3] [--delay-ms 1500] [--refresh]
+ */
+
+import { config } from "dotenv";
+config({ path: [".env.local"] });
+
+import { createHash } from "node:crypto";
+import { getSupabaseServiceClient } from "../../src/lib/supabase/service";
+
+const args = process.argv.slice(2);
+
+function argValue(name: string, fallback: number): number {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1 || index + 1 >= args.length) return fallback;
+  const parsed = parseInt(args[index + 1], 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+const LIMIT = argValue("limit", 50);
+const PAGES = argValue("pages", 3);
+const DELAY_MS = argValue("delay-ms", 1500);
+const REFRESH = args.includes("--refresh");
+
+const REVIEWS_PER_PAGE = 100;
+
+function hashReviewer(steamid: string): string {
+  return createHash("sha256").update(steamid).digest("hex").slice(0, 16);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type ReviewsPage = {
+  success?: number;
+  cursor?: string;
+  reviews?: Array<{ author?: { steamid?: string } }>;
+};
+
+async function fetchReviewerHashes(appid: number): Promise<string[]> {
+  const hashes = new Set<string>();
+  let cursor = "*";
+
+  for (let page = 0; page < PAGES; page++) {
+    const url =
+      `https://store.steampowered.com/appreviews/${appid}` +
+      `?json=1&filter=recent&language=all&purchase_type=all` +
+      `&num_per_page=${REVIEWS_PER_PAGE}&cursor=${encodeURIComponent(cursor)}`;
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.log(`  [${appid}] reviews fetch failed: ${response.status}`);
+      break;
+    }
+
+    const data = (await response.json()) as ReviewsPage;
+    const reviews = data.reviews ?? [];
+    for (const review of reviews) {
+      const steamid = review.author?.steamid;
+      if (steamid) hashes.add(hashReviewer(steamid));
+    }
+
+    if (!data.cursor || data.cursor === cursor || reviews.length < REVIEWS_PER_PAGE) {
+      break;
+    }
+    cursor = data.cursor;
+    await sleep(DELAY_MS);
+  }
+
+  return Array.from(hashes);
+}
+
+async function main() {
+  const supabase = getSupabaseServiceClient();
+
+  const { data: games, error } = await supabase
+    .from("games_new")
+    .select("appid, title")
+    .order("appid", { ascending: true })
+    .limit(10000);
+
+  if (error || !games) {
+    console.error("Failed to fetch catalog:", error?.message);
+    process.exit(1);
+  }
+
+  let crawled = new Set<number>();
+  if (!REFRESH) {
+    const { data: existing } = await supabase
+      .from("steam_review_edges")
+      .select("appid")
+      .limit(100000);
+    crawled = new Set((existing ?? []).map((row: { appid: number }) => row.appid));
+  }
+
+  const todo = games.filter((g: { appid: number }) => !crawled.has(g.appid)).slice(0, LIMIT);
+  console.log(
+    `Catalog: ${games.length} games, ${crawled.size} already crawled, processing ${todo.length} this run`
+  );
+
+  let totalEdges = 0;
+  for (let i = 0; i < todo.length; i++) {
+    const game = todo[i] as { appid: number; title: string };
+    console.log(`[${i + 1}/${todo.length}] ${game.title} (${game.appid})`);
+
+    const hashes = await fetchReviewerHashes(game.appid);
+    if (hashes.length > 0) {
+      const rows = hashes.map((reviewer_hash) => ({
+        appid: game.appid,
+        reviewer_hash,
+      }));
+      const { error: insertError } = await supabase
+        .from("steam_review_edges")
+        .upsert(rows, { onConflict: "appid,reviewer_hash", ignoreDuplicates: true });
+      if (insertError) {
+        console.error(`  insert failed: ${insertError.message}`);
+      } else {
+        totalEdges += rows.length;
+        console.log(`  +${rows.length} reviewer edges`);
+      }
+    } else {
+      console.log("  no reviews found");
+    }
+
+    if (i < todo.length - 1) await sleep(DELAY_MS);
+  }
+
+  console.log(`\nDone. ${totalEdges} edges written this run.`);
+  console.log(
+    "Next: npx tsx scripts/trainer/refresh-coreview-pairs.ts (after enough of the catalog is crawled)"
+  );
+}
+
+void main();

--- a/scripts/trainer/refresh-coreview-pairs.ts
+++ b/scripts/trainer/refresh-coreview-pairs.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Rebuild coreview_pairs from steam_review_edges (PMI-weighted), then print
+ * the strongest pairs as a sanity check.
+ *
+ * Usage:
+ *   npx tsx scripts/trainer/refresh-coreview-pairs.ts [--min-coreviews 3]
+ */
+
+import { config } from "dotenv";
+config({ path: [".env.local"] });
+
+import { getSupabaseServiceClient } from "../../src/lib/supabase/service";
+
+const args = process.argv.slice(2);
+const minIndex = args.indexOf("--min-coreviews");
+const MIN_COREVIEWS =
+  minIndex !== -1 && args[minIndex + 1] ? parseInt(args[minIndex + 1], 10) : 3;
+
+async function main() {
+  const supabase = getSupabaseServiceClient();
+
+  console.log(`Refreshing coreview_pairs (min co-reviews: ${MIN_COREVIEWS})...`);
+  const { data: inserted, error } = await supabase.rpc("refresh_coreview_pairs", {
+    min_coreviews: MIN_COREVIEWS,
+  });
+
+  if (error) {
+    console.error("refresh_coreview_pairs failed:", error.message);
+    process.exit(1);
+  }
+  console.log(`Inserted ${inserted} pairs.\n`);
+
+  const { data: top } = await supabase
+    .from("coreview_pairs")
+    .select("appid_a, appid_b, coreview_count, pmi")
+    .order("pmi", { ascending: false })
+    .limit(20);
+
+  if (!top || top.length === 0) {
+    console.log("No pairs yet — crawl more games with mine-steam-coreviews.ts");
+    return;
+  }
+
+  const appids = Array.from(
+    new Set(top.flatMap((p: { appid_a: number; appid_b: number }) => [p.appid_a, p.appid_b]))
+  );
+  const { data: games } = await supabase
+    .from("games_new")
+    .select("appid, title")
+    .in("appid", appids);
+  const titles = new Map(
+    (games ?? []).map((g: { appid: number; title: string }) => [g.appid, g.title])
+  );
+
+  console.log("Top pairs by PMI:");
+  for (const pair of top) {
+    const a = titles.get(pair.appid_a) ?? pair.appid_a;
+    const b = titles.get(pair.appid_b) ?? pair.appid_b;
+    console.log(
+      `  ${a} <-> ${b}  (co-reviews: ${pair.coreview_count}, pmi: ${pair.pmi.toFixed(2)})`
+    );
+  }
+}
+
+void main();

--- a/scripts/trainer/run-agents.ts
+++ b/scripts/trainer/run-agents.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Source B: agent trainer runs — a cheap model plays the same labeling task
+ * as the human /trainer route. Hard budget cap; rows are tagged
+ * source='agent' so training can down-weight or exclude them.
+ *
+ * Run E7 (agent-fidelity gate) before any bulk run: agents must agree with
+ * human picks on shared screens before their labels are trusted at volume.
+ *
+ * Usage:
+ *   npx tsx scripts/trainer/run-agents.ts [--screens 20] [--budget-usd 0.50] [--model openai/gpt-4o-mini] [--persona cozy-player]
+ */
+
+import { config } from "dotenv";
+config({ path: [".env.local"] });
+
+import { generateText } from "ai";
+import { buildTrainerScreen } from "../../src/lib/trainer/sampler";
+import {
+  createJudgmentSession,
+  insertJudgment,
+} from "../../src/lib/trainer/persist";
+import type { TrainerScreen } from "../../src/lib/trainer/types";
+
+const args = process.argv.slice(2);
+
+function numArg(name: string, fallback: number): number {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1 || index + 1 >= args.length) return fallback;
+  const parsed = parseFloat(args[index + 1]);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+function strArg(name: string, fallback: string): string {
+  const index = args.indexOf(`--${name}`);
+  return index !== -1 && args[index + 1] ? args[index + 1] : fallback;
+}
+
+const SCREENS = numArg("screens", 20);
+const BUDGET_USD = numArg("budget-usd", 0.5);
+const MODEL = strArg("model", "openai/gpt-4o-mini");
+const PERSONA_ID = strArg("persona", "rotate");
+
+// Approximate gpt-4o-mini pricing; update if the model flag changes.
+const PRICE_PER_INPUT_TOKEN = 0.15 / 1_000_000;
+const PRICE_PER_OUTPUT_TOKEN = 0.6 / 1_000_000;
+
+const PERSONAS: Record<string, string> = {
+  "indie-generalist":
+    "You play a wide range of indie games and judge similarity by overall feel: tone, pacing, and what kind of evening the game is for.",
+  "cozy-player":
+    "You play relaxing, low-stress games. Two games are similar only if they share that gentle, comforting quality — mechanics matter less than mood.",
+  "mechanics-purist":
+    "You care about gameplay systems above all. Two games are similar only if their core loops and skill demands genuinely overlap; ignore theme and art style.",
+  "art-game-connoisseur":
+    "You seek experimental, unconventional games. Similarity means shared artistic ambition and strangeness, not genre labels.",
+  "narrative-lover":
+    "You play for story and characters. Similarity means comparable emotional journeys and writing quality.",
+};
+
+function questionFor(screen: TrainerScreen): string {
+  if (screen.facet === "vibe") return "Which candidates FEEL like the seed game (tone, mood, atmosphere)?";
+  if (screen.facet === "mechanics") return "Which candidates PLAY like the seed game (core loop, systems)?";
+  return "Which candidates are genuinely similar to the seed game?";
+}
+
+function buildPrompt(screen: TrainerScreen, personaSpec: string): string {
+  const candidateList = screen.candidates
+    .map(
+      (c) =>
+        `- appid ${c.appid}: "${c.title}" | tags: ${c.topTags.join(", ") || "none"} | ${(c.short_description ?? "").slice(0, 200)}`
+    )
+    .join("\n");
+
+  return `You are labeling game similarity for a recommender. Persona: ${personaSpec}
+
+SEED GAME: "${screen.seed.title}"
+Tags: ${screen.seed.topTags.join(", ") || "none"}
+Description: ${(screen.seed.short_description ?? "").slice(0, 400)}
+
+CANDIDATES:
+${candidateList}
+
+QUESTION: ${questionFor(screen)}
+
+Rules:
+- "picked": candidates a player who loves the seed would also enjoy for the SAME reasons.
+- "rejected": candidates that would clearly disappoint that player (wrong tone or wrong kind of game). Leave out anything you're unsure about.
+- It is fine to pick none.
+
+Return ONLY JSON: {"picked":[appids],"rejected":[appids]}`;
+}
+
+type AgentAnswer = { picked: number[]; rejected: number[] };
+
+function parseAnswer(text: string, shown: Set<number>): AgentAnswer | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as { picked?: unknown; rejected?: unknown };
+    const clamp = (value: unknown): number[] =>
+      Array.isArray(value)
+        ? value
+            .map((v) => (typeof v === "number" ? v : parseInt(String(v), 10)))
+            .filter((v) => Number.isInteger(v) && shown.has(v))
+        : [];
+    const picked = clamp(parsed.picked);
+    const rejectedRaw = clamp(parsed.rejected);
+    const pickedSet = new Set(picked);
+    return { picked, rejected: rejectedRaw.filter((v) => !pickedSet.has(v)) };
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const personaIds =
+    PERSONA_ID === "rotate" ? Object.keys(PERSONAS) : [PERSONA_ID];
+  for (const id of personaIds) {
+    if (!PERSONAS[id]) {
+      console.error(`Unknown persona "${id}". Available: ${Object.keys(PERSONAS).join(", ")}, rotate`);
+      process.exit(1);
+    }
+  }
+
+  console.log(
+    `Agent trainer run: ${SCREENS} screens, model ${MODEL}, personas [${personaIds.join(", ")}], budget $${BUDGET_USD.toFixed(2)}`
+  );
+
+  const sessionIds = new Map<string, string>();
+  let spentUsd = 0;
+  let saved = 0;
+  let failed = 0;
+
+  for (let i = 0; i < SCREENS; i++) {
+    if (spentUsd >= BUDGET_USD) {
+      console.log(`Budget reached ($${spentUsd.toFixed(4)}), stopping.`);
+      break;
+    }
+
+    const personaId = personaIds[i % personaIds.length];
+    const screen = await buildTrainerScreen();
+
+    try {
+      const start = Date.now();
+      const result = await generateText({
+        model: MODEL,
+        prompt: buildPrompt(screen, PERSONAS[personaId]),
+      });
+
+      const inputTokens = result.usage?.inputTokens ?? 0;
+      const outputTokens = result.usage?.outputTokens ?? 0;
+      spentUsd +=
+        inputTokens * PRICE_PER_INPUT_TOKEN + outputTokens * PRICE_PER_OUTPUT_TOKEN;
+
+      const shown = new Set(screen.candidates.map((c) => c.appid));
+      const answer = parseAnswer(result.text, shown);
+      if (!answer) {
+        failed++;
+        console.log(`[${i + 1}/${SCREENS}] ${personaId}: unparseable answer, skipped`);
+        continue;
+      }
+
+      let sessionId = sessionIds.get(personaId);
+      if (!sessionId) {
+        sessionId = await createJudgmentSession({
+          source: "agent",
+          agentModel: MODEL,
+          personaId,
+        });
+        sessionIds.set(personaId, sessionId);
+      }
+
+      await insertJudgment(sessionId, {
+        seedAppid: screen.seed.appid,
+        shownAppids: screen.candidates.map((c) => c.appid),
+        pickedAppids: answer.picked,
+        rejectedAppids: answer.rejected,
+        bestAppid: null,
+        facet: screen.facet,
+        samplerVersion: screen.samplerVersion,
+        latencyMs: Date.now() - start,
+      });
+
+      saved++;
+      console.log(
+        `[${i + 1}/${SCREENS}] ${personaId}: seed "${screen.seed.title}" → ${answer.picked.length} picked, ${answer.rejected.length} rejected ($${spentUsd.toFixed(4)} spent)`
+      );
+    } catch (err) {
+      failed++;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[${i + 1}/${SCREENS}] ${personaId}: ${message}`);
+    }
+  }
+
+  console.log(
+    `\nDone. ${saved} judgments saved, ${failed} failed, total spend ~$${spentUsd.toFixed(4)}.`
+  );
+}
+
+void main();

--- a/scripts/trainer/train.ts
+++ b/scripts/trainer/train.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Fit a linear similarity scorer on collected judgments (BPR / triplet loss).
+ *
+ * Reads similarity_judgments, builds (seed, picked, not-picked) preference
+ * pairs, fits a weight vector over cheap content features, and writes a
+ * versioned JSON artifact with train/holdout pairwise accuracy. The split is
+ * by seed game, so holdout numbers reflect unseen seeds.
+ *
+ * Usage:
+ *   npx tsx scripts/trainer/train.ts [--epochs 30] [--lr 0.05] [--human-weight 1] [--agent-weight 0.3]
+ */
+
+import { config } from "dotenv";
+config({ path: [".env.local"] });
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { getSupabaseServiceClient } from "../../src/lib/supabase/service";
+import { calculateTagSimilarity } from "../../src/lib/utils/steamspy";
+
+const args = process.argv.slice(2);
+
+function numArg(name: string, fallback: number): number {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1 || index + 1 >= args.length) return fallback;
+  const parsed = parseFloat(args[index + 1]);
+  return Number.isNaN(parsed) ? fallback : parsed;
+}
+
+const EPOCHS = numArg("epochs", 30);
+const LEARNING_RATE = numArg("lr", 0.05);
+const HUMAN_WEIGHT = numArg("human-weight", 1);
+const AGENT_WEIGHT = numArg("agent-weight", 0.3);
+const REJECTED_WEIGHT = 2; // explicit "definitely not" is a stronger negative
+const L2 = 1e-4;
+const MAX_PAIRS_PER_JUDGMENT = 40;
+const HOLDOUT_BUCKETS = 5; // seed_appid % 5 === 0 → holdout (~20%)
+
+const FEATURE_NAMES = [
+  "tag_similarity",
+  "shared_tag_count",
+  "same_developer",
+  "candidate_review_ratio",
+  "popularity_gap",
+  "vibe_conflict",
+] as const;
+
+type GameFeatures = {
+  appid: number;
+  tags: Record<string, number>;
+  developers: string[];
+  reviewRatio: number;
+  logOwners: number;
+};
+
+type JudgmentRow = {
+  seed_appid: number;
+  shown_appids: number[];
+  picked_appids: number[];
+  rejected_appids: number[];
+  facet: string | null;
+  judgment_sessions: { source: string } | null;
+};
+
+type Pair = {
+  seed: number;
+  positive: number;
+  negative: number;
+  weight: number;
+};
+
+function parseOwnersMid(owners: string | null): number {
+  if (!owners) return 0;
+  const numbers = owners.match(/[\d,]+/g)?.map((n) => parseInt(n.replace(/,/g, ""), 10));
+  if (!numbers || numbers.length === 0) return 0;
+  return numbers.length >= 2 ? (numbers[0] + numbers[1]) / 2 : numbers[0];
+}
+
+function featureVector(seed: GameFeatures, candidate: GameFeatures): number[] {
+  const { score, sharedTags, vibeConflict } = calculateTagSimilarity(
+    seed.tags,
+    candidate.tags
+  );
+  const seedDevs = new Set(seed.developers.map((d) => d.toLowerCase()));
+  const sameDev = candidate.developers.some((d) => seedDevs.has(d.toLowerCase()))
+    ? 1
+    : 0;
+  const popularityGap = Math.min(
+    Math.abs(seed.logOwners - candidate.logOwners) / 4,
+    1
+  );
+
+  return [
+    score,
+    Math.min(sharedTags.length / 10, 1),
+    sameDev,
+    candidate.reviewRatio,
+    popularityGap,
+    vibeConflict ? 1 : 0,
+  ];
+}
+
+function dot(weights: number[], features: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < weights.length; i++) sum += weights[i] * features[i];
+  return sum;
+}
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+function shuffleInPlace<T>(items: T[]): void {
+  for (let i = items.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [items[i], items[j]] = [items[j], items[i]];
+  }
+}
+
+async function fetchJudgments(): Promise<JudgmentRow[]> {
+  const supabase = getSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from("similarity_judgments")
+    .select(
+      "seed_appid, shown_appids, picked_appids, rejected_appids, facet, judgment_sessions(source)"
+    )
+    .limit(50000);
+
+  if (error) throw new Error(`Failed to fetch judgments: ${error.message}`);
+  return (data ?? []) as unknown as JudgmentRow[];
+}
+
+async function fetchGameFeatures(appids: number[]): Promise<Map<number, GameFeatures>> {
+  const supabase = getSupabaseServiceClient();
+  const result = new Map<number, GameFeatures>();
+
+  for (let i = 0; i < appids.length; i += 200) {
+    const chunk = appids.slice(i, i + 200);
+    const { data, error } = await supabase
+      .from("games_new")
+      .select(
+        "appid, steamspy_tags, developers, steamspy_positive, steamspy_negative, steamspy_owners"
+      )
+      .in("appid", chunk);
+
+    if (error) throw new Error(`Failed to fetch game features: ${error.message}`);
+
+    for (const row of data ?? []) {
+      const positive = row.steamspy_positive ?? 0;
+      const negative = row.steamspy_negative ?? 0;
+      result.set(row.appid, {
+        appid: row.appid,
+        tags: row.steamspy_tags ?? {},
+        developers: row.developers ?? [],
+        reviewRatio: positive + negative > 0 ? positive / (positive + negative) : 0.5,
+        logOwners: Math.log10(parseOwnersMid(row.steamspy_owners) + 1),
+      });
+    }
+  }
+
+  return result;
+}
+
+function buildPairs(
+  judgments: JudgmentRow[],
+  games: Map<number, GameFeatures>
+): { train: Pair[]; holdout: Pair[] } {
+  const train: Pair[] = [];
+  const holdout: Pair[] = [];
+
+  for (const judgment of judgments) {
+    if (!games.has(judgment.seed_appid)) continue;
+
+    const sourceWeight =
+      judgment.judgment_sessions?.source === "human" ? HUMAN_WEIGHT : AGENT_WEIGHT;
+    const picked = new Set(judgment.picked_appids);
+    const rejected = new Set(judgment.rejected_appids);
+
+    const positives = judgment.picked_appids.filter((appid) => games.has(appid));
+    const negatives = judgment.shown_appids
+      .filter((appid) => !picked.has(appid) && games.has(appid))
+      .map((appid) => ({
+        appid,
+        weight: (rejected.has(appid) ? REJECTED_WEIGHT : 1) * sourceWeight,
+      }));
+
+    if (positives.length === 0 || negatives.length === 0) continue;
+
+    const pairs: Pair[] = [];
+    for (const positive of positives) {
+      for (const negative of negatives) {
+        pairs.push({
+          seed: judgment.seed_appid,
+          positive,
+          negative: negative.appid,
+          weight: negative.weight,
+        });
+      }
+    }
+    shuffleInPlace(pairs);
+
+    const bucket = judgment.seed_appid % HOLDOUT_BUCKETS === 0 ? holdout : train;
+    bucket.push(...pairs.slice(0, MAX_PAIRS_PER_JUDGMENT));
+  }
+
+  return { train, holdout };
+}
+
+function pairwiseAccuracy(
+  weights: number[],
+  pairs: Pair[],
+  games: Map<number, GameFeatures>
+): number {
+  if (pairs.length === 0) return 0;
+  let correct = 0;
+  for (const pair of pairs) {
+    const seed = games.get(pair.seed)!;
+    const fp = featureVector(seed, games.get(pair.positive)!);
+    const fn = featureVector(seed, games.get(pair.negative)!);
+    if (dot(weights, fp) > dot(weights, fn)) correct++;
+  }
+  return correct / pairs.length;
+}
+
+async function main() {
+  console.log("Loading judgments...");
+  const judgments = await fetchJudgments();
+  if (judgments.length === 0) {
+    console.log(
+      "No judgments yet. Collect some via /trainer or scripts/trainer/run-agents.ts first."
+    );
+    return;
+  }
+
+  const appids = Array.from(
+    new Set(
+      judgments.flatMap((j) => [j.seed_appid, ...j.shown_appids])
+    )
+  );
+  console.log(`${judgments.length} judgments over ${appids.length} games. Loading features...`);
+  const games = await fetchGameFeatures(appids);
+
+  const { train, holdout } = buildPairs(judgments, games);
+  console.log(`Pairs: ${train.length} train / ${holdout.length} holdout (split by seed)`);
+  if (train.length < 50) {
+    console.log("Not enough training pairs to fit anything meaningful yet.");
+    return;
+  }
+
+  const weights = new Array<number>(FEATURE_NAMES.length).fill(0);
+  for (let epoch = 0; epoch < EPOCHS; epoch++) {
+    shuffleInPlace(train);
+    let loss = 0;
+    for (const pair of train) {
+      const seed = games.get(pair.seed)!;
+      const fp = featureVector(seed, games.get(pair.positive)!);
+      const fn = featureVector(seed, games.get(pair.negative)!);
+      const margin = dot(weights, fp) - dot(weights, fn);
+      const gradScale = pair.weight * (sigmoid(margin) - 1); // d(-log σ(margin))/d(margin)
+      loss += -Math.log(Math.max(sigmoid(margin), 1e-12)) * pair.weight;
+      for (let k = 0; k < weights.length; k++) {
+        weights[k] -=
+          LEARNING_RATE * (gradScale * (fp[k] - fn[k]) + L2 * weights[k]);
+      }
+    }
+    if ((epoch + 1) % 10 === 0 || epoch === 0) {
+      console.log(
+        `  epoch ${epoch + 1}/${EPOCHS}: loss ${(loss / train.length).toFixed(4)}`
+      );
+    }
+  }
+
+  const trainAccuracy = pairwiseAccuracy(weights, train, games);
+  const holdoutAccuracy = pairwiseAccuracy(weights, holdout, games);
+  // Reference: tag similarity alone (the E1-style baseline)
+  const tagOnly = FEATURE_NAMES.map((name) => (name === "tag_similarity" ? 1 : 0));
+  const tagOnlyHoldout = pairwiseAccuracy(tagOnly, holdout, games);
+
+  console.log("\nResults:");
+  console.log(`  train pairwise accuracy:   ${(trainAccuracy * 100).toFixed(1)}%`);
+  console.log(`  holdout pairwise accuracy: ${(holdoutAccuracy * 100).toFixed(1)}%`);
+  console.log(`  tag-sim-only holdout:      ${(tagOnlyHoldout * 100).toFixed(1)}%`);
+  console.log("\nWeights:");
+  FEATURE_NAMES.forEach((name, i) => {
+    console.log(`  ${name.padEnd(24)} ${weights[i].toFixed(4)}`);
+  });
+
+  const artifactDir = path.join(__dirname, "artifacts");
+  mkdirSync(artifactDir, { recursive: true });
+  const artifactPath = path.join(
+    artifactDir,
+    `weights-${new Date().toISOString().replace(/[:.]/g, "-")}.json`
+  );
+  writeFileSync(
+    artifactPath,
+    JSON.stringify(
+      {
+        createdAt: new Date().toISOString(),
+        featureNames: FEATURE_NAMES,
+        weights,
+        config: {
+          epochs: EPOCHS,
+          learningRate: LEARNING_RATE,
+          humanWeight: HUMAN_WEIGHT,
+          agentWeight: AGENT_WEIGHT,
+          rejectedWeight: REJECTED_WEIGHT,
+          l2: L2,
+        },
+        data: {
+          judgments: judgments.length,
+          trainPairs: train.length,
+          holdoutPairs: holdout.length,
+        },
+        metrics: {
+          trainAccuracy,
+          holdoutAccuracy,
+          tagSimilarityOnlyHoldoutAccuracy: tagOnlyHoldout,
+        },
+      },
+      null,
+      2
+    )
+  );
+  console.log(`\nArtifact written: ${artifactPath}`);
+}
+
+void main();

--- a/src/app/trainer/actions.ts
+++ b/src/app/trainer/actions.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { z } from "zod";
+import {
+  createJudgmentSession,
+  insertJudgment,
+  sessionExists,
+} from "@/lib/trainer/persist";
+import type { SubmitJudgmentInput } from "@/lib/trainer/types";
+
+const SESSION_COOKIE = "trainer_session_id";
+
+const judgmentSchema = z.object({
+  seedAppid: z.number().int().positive(),
+  shownAppids: z.array(z.number().int().positive()).min(2).max(12),
+  pickedAppids: z.array(z.number().int().positive()),
+  rejectedAppids: z.array(z.number().int().positive()),
+  bestAppid: z.number().int().positive().nullable(),
+  facet: z.enum(["vibe", "mechanics"]).nullable(),
+  samplerVersion: z.string().min(1),
+  latencyMs: z.number().int().nonnegative(),
+});
+
+export async function submitJudgment(
+  input: SubmitJudgmentInput
+): Promise<{ success: boolean; error?: string }> {
+  if (process.env.TRAINER_ENABLED !== "true") {
+    return { success: false, error: "Trainer is disabled" };
+  }
+
+  const parsed = judgmentSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Invalid judgment payload" };
+  }
+
+  const judgment = parsed.data;
+  const shown = new Set(judgment.shownAppids);
+  const allReferenced = [
+    ...judgment.pickedAppids,
+    ...judgment.rejectedAppids,
+    ...(judgment.bestAppid ? [judgment.bestAppid] : []),
+  ];
+  if (allReferenced.some((appid) => !shown.has(appid))) {
+    return { success: false, error: "Picked games must be among shown games" };
+  }
+
+  const cookieStore = await cookies();
+  let sessionId = cookieStore.get(SESSION_COOKIE)?.value;
+
+  if (!sessionId || !(await sessionExists(sessionId))) {
+    sessionId = await createJudgmentSession({ source: "human" });
+    cookieStore.set(SESSION_COOKIE, sessionId, {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 30,
+    });
+  }
+
+  try {
+    await insertJudgment(sessionId, judgment);
+    return { success: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return { success: false, error: message };
+  }
+}

--- a/src/app/trainer/page.tsx
+++ b/src/app/trainer/page.tsx
@@ -1,0 +1,24 @@
+import { notFound } from "next/navigation";
+import { buildTrainerScreen } from "@/lib/trainer/sampler";
+import { TrainerClient } from "./trainer-client";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = {
+  title: "Trainer | IndieFindr",
+  robots: { index: false, follow: false },
+};
+
+export default async function TrainerPage() {
+  if (process.env.TRAINER_ENABLED !== "true") {
+    notFound();
+  }
+
+  const screen = await buildTrainerScreen();
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <TrainerClient key={screen.seed.appid} screen={screen} />
+    </main>
+  );
+}

--- a/src/app/trainer/trainer-client.tsx
+++ b/src/app/trainer/trainer-client.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+import { Check, X } from "lucide-react";
+import { submitJudgment } from "./actions";
+import type { TrainerScreen } from "@/lib/trainer/types";
+
+type Mark = "none" | "similar" | "not";
+
+function questionFor(screen: TrainerScreen): string {
+  if (screen.facet === "vibe") {
+    return `Which of these FEEL like ${screen.seed.title}?`;
+  }
+  if (screen.facet === "mechanics") {
+    return `Which of these PLAY like ${screen.seed.title}?`;
+  }
+  return `Which of these are similar to ${screen.seed.title}?`;
+}
+
+export function TrainerClient({ screen }: { screen: TrainerScreen }) {
+  const router = useRouter();
+  const [marks, setMarks] = useState<Record<number, Mark>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const startedAt = useRef(0);
+
+  useEffect(() => {
+    startedAt.current = Date.now();
+  }, []);
+
+  const counts = useMemo(() => {
+    const values = Object.values(marks);
+    return {
+      similar: values.filter((m) => m === "similar").length,
+      not: values.filter((m) => m === "not").length,
+    };
+  }, [marks]);
+
+  function cycleMark(appid: number) {
+    setMarks((prev) => {
+      const current = prev[appid] ?? "none";
+      const next: Mark =
+        current === "none" ? "similar" : current === "similar" ? "not" : "none";
+      return { ...prev, [appid]: next };
+    });
+  }
+
+  function submit() {
+    setError(null);
+    startTransition(async () => {
+      const result = await submitJudgment({
+        seedAppid: screen.seed.appid,
+        shownAppids: screen.candidates.map((c) => c.appid),
+        pickedAppids: screen.candidates
+          .filter((c) => marks[c.appid] === "similar")
+          .map((c) => c.appid),
+        rejectedAppids: screen.candidates
+          .filter((c) => marks[c.appid] === "not")
+          .map((c) => c.appid),
+        bestAppid: null,
+        facet: screen.facet,
+        samplerVersion: screen.samplerVersion,
+        latencyMs: startedAt.current ? Date.now() - startedAt.current : 0,
+      });
+
+      if (!result.success) {
+        setError(result.error ?? "Failed to save");
+        return;
+      }
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-4 items-start">
+        <div className="relative w-48 shrink-0 overflow-hidden rounded-md bg-muted aspect-steam">
+          {screen.seed.header_image && (
+            <Image
+              src={screen.seed.header_image}
+              alt={screen.seed.title}
+              fill
+              sizes="192px"
+              className="object-cover"
+              priority
+            />
+          )}
+        </div>
+        <div className="flex flex-col gap-1 min-w-0">
+          <h1 className="text-lg font-semibold">{questionFor(screen)}</h1>
+          {screen.seed.short_description && (
+            <p className="text-sm text-muted-foreground line-clamp-3">
+              {screen.seed.short_description}
+            </p>
+          )}
+          {screen.seed.topTags.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {screen.seed.topTags.join(" · ")}
+            </p>
+          )}
+          <p className="text-xs text-muted-foreground mt-1">
+            Tap once = similar, twice = definitely not, three times = clear.
+            Skip anything you don&apos;t know.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {screen.candidates.map((candidate) => {
+          const mark = marks[candidate.appid] ?? "none";
+          return (
+            <button
+              key={candidate.appid}
+              type="button"
+              onClick={() => cycleMark(candidate.appid)}
+              className="text-left group"
+            >
+              <div
+                className={`relative w-full mb-2 overflow-hidden rounded-md bg-muted aspect-steam ring-2 transition-colors ${
+                  mark === "similar"
+                    ? "ring-green-500"
+                    : mark === "not"
+                      ? "ring-red-500"
+                      : "ring-transparent group-hover:ring-border"
+                }`}
+              >
+                {candidate.header_image && (
+                  <Image
+                    src={candidate.header_image}
+                    alt={candidate.title}
+                    fill
+                    sizes="(max-width: 640px) 50vw, 25vw"
+                    className="object-cover"
+                  />
+                )}
+                {mark === "similar" && (
+                  <span className="absolute top-1 right-1 rounded-full bg-green-500 text-white p-1">
+                    <Check className="size-3" />
+                  </span>
+                )}
+                {mark === "not" && (
+                  <span className="absolute top-1 right-1 rounded-full bg-red-500 text-white p-1">
+                    <X className="size-3" />
+                  </span>
+                )}
+              </div>
+              <div className="font-medium text-sm line-clamp-1">
+                {candidate.title}
+              </div>
+              <div className="text-xs text-muted-foreground line-clamp-1">
+                {candidate.topTags.slice(0, 3).join(" · ")}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={isPending}
+          className="rounded-md bg-foreground text-background px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {isPending
+            ? "Saving…"
+            : counts.similar === 0 && counts.not === 0
+              ? "None of these — next"
+              : "Submit & next"}
+        </button>
+        <span className="text-xs text-muted-foreground">
+          {counts.similar} similar · {counts.not} not
+        </span>
+        {error && <span className="text-xs text-red-500">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/trainer/persist.ts
+++ b/src/lib/trainer/persist.ts
@@ -1,0 +1,58 @@
+import { getSupabaseServiceClient } from "../supabase/service";
+import type { SubmitJudgmentInput } from "./types";
+
+export type SessionSource = "human" | "agent";
+
+export async function createJudgmentSession(params: {
+  source: SessionSource;
+  agentModel?: string;
+  personaId?: string;
+}): Promise<string> {
+  const supabase = getSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from("judgment_sessions")
+    .insert({
+      source: params.source,
+      agent_model: params.agentModel ?? null,
+      persona_id: params.personaId ?? null,
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Failed to create judgment session: ${error?.message}`);
+  }
+  return data.id as string;
+}
+
+export async function sessionExists(sessionId: string): Promise<boolean> {
+  const supabase = getSupabaseServiceClient();
+  const { data } = await supabase
+    .from("judgment_sessions")
+    .select("id")
+    .eq("id", sessionId)
+    .maybeSingle();
+  return Boolean(data);
+}
+
+export async function insertJudgment(
+  sessionId: string,
+  judgment: SubmitJudgmentInput
+): Promise<void> {
+  const supabase = getSupabaseServiceClient();
+  const { error } = await supabase.from("similarity_judgments").insert({
+    session_id: sessionId,
+    seed_appid: judgment.seedAppid,
+    shown_appids: judgment.shownAppids,
+    picked_appids: judgment.pickedAppids,
+    best_appid: judgment.bestAppid,
+    rejected_appids: judgment.rejectedAppids,
+    facet: judgment.facet,
+    sampler_version: judgment.samplerVersion,
+    latency_ms: judgment.latencyMs,
+  });
+
+  if (error) {
+    throw new Error(`Failed to insert judgment: ${error.message}`);
+  }
+}

--- a/src/lib/trainer/sampler.ts
+++ b/src/lib/trainer/sampler.ts
@@ -1,0 +1,151 @@
+import { getSupabaseServiceClient } from "../supabase/service";
+import { calculateTagSimilarity, getTopTags } from "../utils/steamspy";
+import type {
+  TrainerCandidate,
+  TrainerFacet,
+  TrainerGame,
+  TrainerScreen,
+} from "./types";
+
+export const SAMPLER_VERSION = "tags-v1";
+
+const SCREEN_SIZE = 8;
+const TOP_PICKS = 3; // confirm/deny the current model's belief
+const NEAR_PICKS = 3; // hard cases: similar-ish by tags, where labels matter most
+const RANDOM_PICKS = SCREEN_SIZE - TOP_PICKS - NEAR_PICKS;
+const CANDIDATE_SAMPLE = 160;
+const FACET_SCREEN_RATE = 0.2;
+const MIN_SEED_TAGS = 5;
+const MIN_CANDIDATE_TAGS = 3;
+
+type GameRow = {
+  appid: number;
+  title: string;
+  header_image: string | null;
+  short_description: string | null;
+  steamspy_tags: Record<string, number> | null;
+};
+
+function shuffle<T>(items: T[]): T[] {
+  const result = [...items];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+function toTrainerGame(row: GameRow): TrainerGame {
+  return {
+    appid: row.appid,
+    title: row.title,
+    header_image: row.header_image,
+    short_description: row.short_description,
+    topTags: getTopTags(row.steamspy_tags ?? {}, 5),
+  };
+}
+
+async function fetchTaggedAppids(): Promise<number[]> {
+  const supabase = getSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from("games_new")
+    .select("appid")
+    .not("steamspy_tags", "is", null)
+    .limit(10000);
+
+  if (error) throw new Error(`Failed to fetch appid pool: ${error.message}`);
+  return (data ?? []).map((row: { appid: number }) => row.appid);
+}
+
+async function fetchGames(appids: number[]): Promise<GameRow[]> {
+  const supabase = getSupabaseServiceClient();
+  const { data, error } = await supabase
+    .from("games_new")
+    .select("appid, title, header_image, short_description, steamspy_tags")
+    .in("appid", appids);
+
+  if (error) throw new Error(`Failed to fetch games: ${error.message}`);
+  return (data ?? []) as GameRow[];
+}
+
+async function pickSeed(pool: number[], seedAppid?: number): Promise<GameRow> {
+  if (seedAppid) {
+    const [seed] = await fetchGames([seedAppid]);
+    if (!seed) throw new Error(`Seed game ${seedAppid} not found`);
+    return seed;
+  }
+
+  // Sample a handful and keep the first with enough tags to score against
+  const sampled = shuffle(pool).slice(0, 20);
+  const rows = await fetchGames(sampled);
+  const eligible = rows.find(
+    (row) => Object.keys(row.steamspy_tags ?? {}).length >= MIN_SEED_TAGS
+  );
+  if (!eligible) {
+    throw new Error(
+      "No seed candidates with enough tags — run the steamspy tag backfill first"
+    );
+  }
+  return eligible;
+}
+
+/**
+ * Build one labeling screen: a seed game plus a deliberate mix of candidates —
+ * top tag-similarity picks, near misses (hard cases), and popularity-agnostic
+ * random picks for exploration coverage.
+ */
+export async function buildTrainerScreen(seedAppid?: number): Promise<TrainerScreen> {
+  const pool = await fetchTaggedAppids();
+  if (pool.length < SCREEN_SIZE * 4) {
+    throw new Error(
+      `Catalog too small for trainer screens (${pool.length} tagged games)`
+    );
+  }
+
+  const seed = await pickSeed(pool, seedAppid);
+
+  const sampleIds = shuffle(pool.filter((id) => id !== seed.appid)).slice(
+    0,
+    CANDIDATE_SAMPLE
+  );
+  const rows = await fetchGames(sampleIds);
+
+  const scored = rows
+    .filter((row) => Object.keys(row.steamspy_tags ?? {}).length >= MIN_CANDIDATE_TAGS)
+    .map((row) => ({
+      row,
+      score: calculateTagSimilarity(seed.steamspy_tags ?? {}, row.steamspy_tags ?? {})
+        .score,
+    }))
+    .sort((a, b) => b.score - a.score);
+
+  if (scored.length < SCREEN_SIZE * 2) {
+    throw new Error("Not enough tagged candidates to build a screen");
+  }
+
+  const top = scored.slice(0, TOP_PICKS);
+  const nearPool = scored.slice(TOP_PICKS, Math.min(40, scored.length - RANDOM_PICKS));
+  const near = shuffle(nearPool).slice(0, NEAR_PICKS);
+
+  const used = new Set([...top, ...near].map((entry) => entry.row.appid));
+  const randomPool = scored.filter((entry) => !used.has(entry.row.appid));
+  const random = shuffle(randomPool).slice(0, RANDOM_PICKS);
+
+  const candidates: TrainerCandidate[] = shuffle([
+    ...top.map((entry) => ({ ...toTrainerGame(entry.row), slot: "top" as const })),
+    ...near.map((entry) => ({ ...toTrainerGame(entry.row), slot: "near" as const })),
+    ...random.map((entry) => ({ ...toTrainerGame(entry.row), slot: "random" as const })),
+  ]);
+
+  let facet: TrainerFacet | null = null;
+  if (Math.random() < FACET_SCREEN_RATE) {
+    facet = Math.random() < 0.5 ? "vibe" : "mechanics";
+  }
+
+  return {
+    seed: toTrainerGame(seed),
+    candidates,
+    facet,
+    samplerVersion: SAMPLER_VERSION,
+  };
+}

--- a/src/lib/trainer/types.ts
+++ b/src/lib/trainer/types.ts
@@ -1,0 +1,34 @@
+export type TrainerFacet = "vibe" | "mechanics";
+
+export type CandidateSlot = "top" | "near" | "random";
+
+export type TrainerGame = {
+  appid: number;
+  title: string;
+  header_image: string | null;
+  short_description: string | null;
+  topTags: string[];
+};
+
+export type TrainerCandidate = TrainerGame & {
+  /** How the sampler chose this candidate (logged via sampler_version semantics) */
+  slot: CandidateSlot;
+};
+
+export type TrainerScreen = {
+  seed: TrainerGame;
+  candidates: TrainerCandidate[];
+  facet: TrainerFacet | null;
+  samplerVersion: string;
+};
+
+export type SubmitJudgmentInput = {
+  seedAppid: number;
+  shownAppids: number[];
+  pickedAppids: number[];
+  rejectedAppids: number[];
+  bestAppid: number | null;
+  facet: TrainerFacet | null;
+  samplerVersion: string;
+  latencyMs: number;
+};

--- a/supabase/migrations/20260613000000_add_similarity_judgments.sql
+++ b/supabase/migrations/20260613000000_add_similarity_judgments.sql
@@ -1,0 +1,101 @@
+-- Similarity judgments: interaction data for the trainer
+-- (docs/interaction-trained-recommender.md)
+--
+-- judgment_sessions / similarity_judgments: one row per labeling screen,
+-- with the full impression set logged so the data supports unbiased eval.
+-- steam_review_edges / coreview_pairs: mined Steam co-review signal (Source A).
+
+CREATE TABLE IF NOT EXISTS judgment_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source TEXT NOT NULL CHECK (source IN ('human', 'agent')),
+  agent_model TEXT,
+  persona_id TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS similarity_judgments (
+  id BIGSERIAL PRIMARY KEY,
+  session_id UUID NOT NULL REFERENCES judgment_sessions(id) ON DELETE CASCADE,
+  seed_appid BIGINT NOT NULL REFERENCES games_new(appid) ON DELETE CASCADE,
+  shown_appids BIGINT[] NOT NULL,
+  picked_appids BIGINT[] NOT NULL,
+  best_appid BIGINT,
+  rejected_appids BIGINT[] NOT NULL DEFAULT '{}',
+  -- NULL = overall similarity question; otherwise the facet the screen asked about
+  facet TEXT CHECK (facet IN ('vibe', 'mechanics')),
+  sampler_version TEXT NOT NULL,
+  latency_ms INTEGER,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_similarity_judgments_seed
+  ON similarity_judgments(seed_appid);
+CREATE INDEX IF NOT EXISTS idx_similarity_judgments_session
+  ON similarity_judgments(session_id);
+
+-- Reviewer ids are hashed before storage; we only need co-occurrence, not identity.
+CREATE TABLE IF NOT EXISTS steam_review_edges (
+  appid BIGINT NOT NULL,
+  reviewer_hash TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (appid, reviewer_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_steam_review_edges_reviewer
+  ON steam_review_edges(reviewer_hash);
+
+CREATE TABLE IF NOT EXISTS coreview_pairs (
+  appid_a BIGINT NOT NULL,
+  appid_b BIGINT NOT NULL,
+  coreview_count INTEGER NOT NULL,
+  pmi DOUBLE PRECISION NOT NULL,
+  computed_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (appid_a, appid_b),
+  CHECK (appid_a < appid_b)
+);
+
+CREATE INDEX IF NOT EXISTS idx_coreview_pairs_a ON coreview_pairs(appid_a);
+CREATE INDEX IF NOT EXISTS idx_coreview_pairs_b ON coreview_pairs(appid_b);
+
+-- Rebuild coreview_pairs from steam_review_edges with PMI weighting
+-- (so co-occurrence with mega-hits doesn't dominate). Returns rows inserted.
+CREATE OR REPLACE FUNCTION refresh_coreview_pairs(min_coreviews INTEGER DEFAULT 3)
+RETURNS INTEGER AS $$
+DECLARE
+  total_reviewers BIGINT;
+  inserted INTEGER;
+BEGIN
+  SELECT COUNT(DISTINCT reviewer_hash) INTO total_reviewers FROM steam_review_edges;
+  IF total_reviewers = 0 THEN
+    RETURN 0;
+  END IF;
+
+  DELETE FROM coreview_pairs;
+
+  INSERT INTO coreview_pairs (appid_a, appid_b, coreview_count, pmi)
+  SELECT
+    e1.appid,
+    e2.appid,
+    COUNT(*)::INTEGER,
+    LN((COUNT(*)::DOUBLE PRECISION * total_reviewers) / (ca.cnt::DOUBLE PRECISION * cb.cnt::DOUBLE PRECISION))
+  FROM steam_review_edges e1
+  JOIN steam_review_edges e2
+    ON e1.reviewer_hash = e2.reviewer_hash AND e1.appid < e2.appid
+  JOIN (SELECT appid, COUNT(*) AS cnt FROM steam_review_edges GROUP BY appid) ca
+    ON ca.appid = e1.appid
+  JOIN (SELECT appid, COUNT(*) AS cnt FROM steam_review_edges GROUP BY appid) cb
+    ON cb.appid = e2.appid
+  GROUP BY e1.appid, e2.appid, ca.cnt, cb.cnt
+  HAVING COUNT(*) >= min_coreviews;
+
+  GET DIAGNOSTICS inserted = ROW_COUNT;
+  RETURN inserted;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Training data is written only by trusted server contexts (service role
+-- bypasses RLS); no public policies on purpose.
+ALTER TABLE judgment_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE similarity_judgments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE steam_review_edges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE coreview_pairs ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Scientific-method plan to move LLM calls off the suggestion request
path: baseline cost/quality measurement, calibrated pairwise judge,
then tag-vector, embedding-kNN, distilled-reranker, and weight-tuning
experiments with pre-registered promotion gates. Includes immediate
stop-the-bleed fixes for the page-view trigger and retry/fan-out
cost amplifiers.

https://claude.ai/code/session_01C2jou9bDi3weBZPMTtmJPS